### PR TITLE
Force use of bash for Vader tests.

### DIFF
--- a/test/run
+++ b/test/run
@@ -33,6 +33,7 @@ make_dirs xxx/after
 
 cat > /tmp/mini-vimrc << VIMRC
 set rtp+=vader.vim
+set shell=/bin/bash
 source $PLUG_SRC
 VIMRC
 


### PR DESCRIPTION
If not using a bash compatible shell (like fish), then this will be
set as the default Vim shell. Leading to half the tests failing with
E484: CAN’T OPEN FILE
