### PR TITLE
Allow use of ssh over https for pulling repos

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -379,7 +379,7 @@ function! s:infer_properties(name, repo)
       if repo !~ '/'
         let repo = 'vim-scripts/'. repo
       endif
-      if g:plug_use_ssh == 1
+      if exists('g:plug_use_ssh') && g:plug_use_ssh == 1
           let uri = 'git@github.com:' . repo . '.git'
       else
           let uri = 'https://git::@github.com/' . repo . '.git'


### PR DESCRIPTION
This is a simple change that will allow the use of github ssh urls over https.
