### PR TITLE
Do not cd from vim but directly in the shell in preview commit

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -1176,14 +1176,14 @@ function! s:preview_commit()
     return
   endif
 
-  execute 'cd '.s:esc(g:plugs[name].dir)
-  execute 'pedit '.sha
+  execute 'pedit' sha
   wincmd P
   setlocal filetype=git buftype=nofile nobuflisted
-  execute 'silent read !git show '.sha
-  normal! ggdd
-  wincmd p
+  execute 'cd' s:esc(g:plugs[name].dir)
+  execute 'silent read !git show' sha
   cd -
+  normal! gg"_dd
+  wincmd p
 endfunction
 
 function! s:section(flags)


### PR DESCRIPTION
I have [this](https://github.com/vheon/dotvim/blob/eeca7006c9e78a70579dc57b7c8ba4ea3f5ee0ef/vimrc#L340-L352) in my vimrc for changing the current working directory and was messing with this functionality. Basically if I had more than one plugin with changes hitting `<Enter>` on a sha of a plugin the diff gets displayed in the preview window but if I then hit `<Enter>` on a sha of a different plugin I read in the preview window an error as if it was trying to `git show 'sha'` in the wrong repo. This should fix it but cannot test it on windows. Can you give it a look?
