### PR TITLE
Update: job_data[2] as a list.

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -122,6 +122,10 @@ function! s:to_a(v)
   return type(a:v) == s:TYPE.list ? a:v : [a:v]
 endfunction
 
+function! s:to_s(v)
+  return type(a:v) == s:TYPE.string ? a:v : join(a:v, "\n") . "\n"
+endfunction
+
 function! s:source(from, ...)
   for pattern in a:000
     for vim in s:lines(globpath(a:from, pattern))
@@ -772,7 +776,7 @@ function! s:job_handler() abort
     call s:reap(name)
     call s:tick()
   else
-    let job.result .= v:job_data[2]
+    let job.result .= s:to_s(v:job_data[2])
     " To reduce the number of buffer updates
     let job.tick = get(job, 'tick', -1) + 1
     if job.tick % len(s:jobs) == 0


### PR DESCRIPTION
This parallels neovim/neovim#1255 (it's one of my test cases). Just changes `v:job_data[2]` to `join(v:job_data[2], "\n") . "\n"` because making all references of `job.result` seemed obtuse to the rest of the code.
