### PR TITLE
Check for full match of command name

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -171,7 +171,7 @@ function! plug#end()
           endif
           call add(s:triggers[name].map, cmd)
         elseif cmd =~ '^[A-Z]'
-          if !exists(':'.cmd)
+          if exists(':'.cmd) != 2
             execute printf(
             \ 'command! -nargs=* -range -bang %s call s:lod_cmd(%s, "<bang>", <line1>, <line2>, <q-args>, %s)',
             \ cmd, string(cmd), string(name))


### PR DESCRIPTION
I ran into an issue with vim-abolish which has a command named `:S`. `exists(':S')` is non-zero because there are other commands that only start with an S, so vim-plug doesn't create the command and my setting `Plug 'tpope/vim-abolish', {'on': 'S'}` does not work. The check if the command exists should check the return value of `exists()` to make sure the full command name exists instead of just a command or multiple commands starting with the same string.
