### PR TITLE
Don't force filetype plugin and indent

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -212,7 +212,7 @@ function! plug#end()
   endfor
 
   call s:reorg_rtp()
-  filetype plugin indent on
+  filetype on
   if has('vim_starting')
     syntax enable
   else


### PR DESCRIPTION
Use previously set plugin and indent flags when re-enabling filetype detection. Calling `filetype on` will leave `plugin` and `indent` flags unchanged, allowing a user to specify these value (anywhere before `plug#end()`).