### PR TITLE
Python parallel plugin management.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
   - 1.8.7
-  - 2.0.0
   - 1.9.2 # Test with vim-nox package on ubuntu
+  - 1.9.3 # Test against python installer
+  - 2.0.0
 
 before_script: |
   if [ $(ruby -e 'puts RUBY_VERSION') = 1.9.2 ]; then
@@ -12,7 +13,13 @@ before_script: |
   else
     hg clone https://code.google.com/p/vim/
     cd vim
-    ./configure --with-features=huge --enable-rubyinterp
+    if [ $(ruby -e 'puts RUBY_VERSION') = 1.9.3 ]; then
+      sudo apt-get update -y
+      sudo apt-get install -y python2.7-dev
+      ./configure --with-features=huge --enable-pythoninterp
+    else
+      ./configure --with-features=huge --enable-rubyinterp
+    fi
     make
     sudo make install
     cd -

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A minimalist Vim plugin manager.
 - Easier to setup: Single file. No boilerplate code required.
 - Easier to use: Concise, intuitive syntax
 - [Super-fast][40/4] parallel installation/update
-  (with [+ruby][rb] or [Neovim][nv])
+  (with +python or [+ruby][rb] or [Neovim][nv])
 - On-demand loading for [faster startup time][startup-time]
 - Can review and rollback updates
 - Branch/tag support
@@ -88,13 +88,13 @@ Reload .vimrc and `:PlugInstall` to install plugins.
 
 ### Global options
 
-| Flag                | Default                           | Description                                                 |
-| ------------------- | --------------------------------- | ----------------------------------------------------------- |
-| `g:plug_threads`    | 16                                | Default number of threads to use                            |
-| `g:plug_timeout`    | 60                                | Time limit of each task in seconds (*for Ruby installer*)   |
-| `g:plug_retries`    | 2                                 | Number of retries in case of timeout (*for Ruby installer*) |
-| `g:plug_window`     | `vertical topleft new`            | Command to open plug window                                 |
-| `g:plug_url_format` | `https://git::@github.com/%s.git` | `printf` format to build repo URL                           |
+| Flag                | Default                           | Description                                                |
+| ------------------- | --------------------------------- | -----------------------------------------------------------|
+| `g:plug_threads`    | 16                                | Default number of threads to use                           |
+| `g:plug_timeout`    | 60                                | Time limit of each task in seconds (*Ruby & Python*)   |
+| `g:plug_retries`    | 2                                 | Number of retries in case of timeout (*Ruby & Python*) |
+| `g:plug_window`     | `vertical topleft new`            | Command to open plug window                                |
+| `g:plug_url_format` | `https://git::@github.com/%s.git` | `printf` format to build repo URL                          |
 
 ### Keybindings
 

--- a/test/test.vader
+++ b/test/test.vader
@@ -39,9 +39,13 @@ Execute (Initialize test environment):
     endif
   endfunction
 
-Execute (Print Ruby version):
+Execute (Print Interpreter Version):
   redir => out
-  silent ruby puts RUBY_VERSION
+  if has('ruby')
+    silent ruby puts 'Ruby: ' + RUBY_VERSION
+  elseif has('python')
+    silent python import sys; svi = sys.version_info; print 'Python: {}.{}.{}'.format(svi[0], svi[1], svi[2])
+  endif
   redir END
   Log substitute(out, '\n', '', 'g')
 


### PR DESCRIPTION
Log:
* Main difference from ruby is inside Command class, notably it
poll/sleeps on the subprocess to check output & timeout. Not overly taxing CPU.
* Otherwise, I mainly just mirrored logic into an OOP style.
* Note that due to GVim freeze, disabling use on Windows. Also, likely
other issues.
---------------------------------------

I've squashed and cleaned up the commit and everything seems to work.
One thing I should note, is that unlike ruby, the update_python function blocks (i.e. :PlugInstall when using Python).
I think it may be a difference in the Python embedded interpreter that I can't fix. We can make a ticket here to look at it, minor issue.

Hope it is to your liking @junegunn . I've mainly testing on Ubuntu 14.04, someone like @vheon maybe should do a complete re-run of everything on Mac. 

IMPORTANT: For testing purposes, if you have +ruby & +python it always chooses the ruby version. To test either manually false the s:ruby flag or compile a python only version.
