### PR TITLE
Do not inject `git::` to url when git 2.3.0 or above found

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -718,6 +718,15 @@ function! s:update_impl(pull, force, args) abort
     return
   endif
 
+  if !s:is_win && s:git_version_requirement(2, 3)
+    let git_terminal_prompt = exists('$GIT_TERMINAL_PROMPT') ? $GIT_TERMINAL_PROMPT : ''
+    let $GIT_TERMINAL_PROMPT = 0
+    for plug in values(todo)
+      let plug.uri = substitute(plug.uri,
+            \ '^https://git::@github\.com', 'https://github.com', '')
+    endfor
+  endif
+
   if !isdirectory(g:plug_home)
     try
       call mkdir(g:plug_home, 'p')
@@ -773,6 +782,10 @@ function! s:update_impl(pull, force, args) abort
     endtry
   else
     call s:update_vim()
+  endif
+
+  if exists('git_terminal_prompt')
+    let $GIT_TERMINAL_PROMPT = git_terminal_prompt
   endif
 endfunction
 


### PR DESCRIPTION
Related: #161 
/cc @bruno-

This commit takes advantage of `$GIT_TERMINAL_PROMPT` variable added in git 2.3.0. So if the git installed on the system is 2.3.0 or above, vim-plug will not use `git::` hack to prevent user prompt. However, the downside of the current implementation is that it runs `git --version` command on startup which should increase the startup time by a little.