### PR TITLE
Use :pgroup option when starting subprocesses

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -1003,23 +1003,36 @@ function! s:update_ruby()
     %["#{arg.gsub('"', '\"')}"]
   end
 
-  def killall pid
-    pids = [pid]
-    unless `which pgrep 2> /dev/null`.empty?
-      children = pids
-      until children.empty?
-        children = children.map { |pid|
-          `pgrep -P #{pid}`.lines.map { |l| l.chomp }
-        }.flatten
-        pids += children
-      end
-    end
-    pids.each { |pid| Process.kill 'TERM', pid.to_i rescue nil }
-  end
-
+  require 'rubygems'
   require 'thread'
   require 'fileutils'
   require 'timeout'
+
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('1.9')
+    def popen cmd
+      IO.popen(cmd, :pgroup => true)
+    end
+    def killall pid
+      Process.kill 'TERM', - pid rescue nil
+    end
+  else
+    def popen cmd
+      IO.popen(cmd)
+    end
+    def killall pid
+      pids = [pid]
+      unless `which pgrep 2> /dev/null`.empty?
+        children = pids
+        until children.empty?
+          children = children.map { |pid|
+            `pgrep -P #{pid}`.lines.map { |l| l.chomp }
+          }.flatten
+          pids += children
+        end
+      end
+      pids.each { |pid| Process.kill 'TERM', pid.to_i rescue nil }
+    end
+  end
   running = true
   iswin = VIM::evaluate('s:is_win').to_i == 1
   pull  = VIM::evaluate('s:update.pull').to_i == 1
@@ -1086,7 +1099,7 @@ function! s:update_ruby()
           File.unlink tmp rescue nil
         end
       else
-        fd = IO.popen(cmd).extend(PlugStream)
+        fd = popen(cmd).extend(PlugStream)
         first_line = true
         log_prob = 1.0 / nthr
         while line = Timeout::timeout(timeout) { fd.get_line }


### PR DESCRIPTION
This makes it easier and faster to kill spawned git processes.
Repetitive `pgrep` command for collecting PIDs is no longer required.
Unfortunately, :pgroup option is not supported on Ruby 1.8 so we can't
remove the old implementation of `killall`.

/cc @starcraftman