### PR TITLE
Disable Python on Cygwin

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -73,7 +73,7 @@ let s:plug_tab = get(s:, 'plug_tab', -1)
 let s:plug_buf = get(s:, 'plug_buf', -1)
 let s:mac_gui = has('gui_macvim') && has('gui_running')
 let s:is_win = has('win32') || has('win64')
-let s:py2 = has('python') && !s:is_win
+let s:py2 = has('python') && !s:is_win && !has('win32unix')
 let s:ruby = has('ruby') && (v:version >= 703 || v:version == 702 && has('patch374'))
 let s:nvim = has('nvim') && !s:is_win
 let s:me = resolve(expand('<sfile>:p'))


### PR DESCRIPTION
Temporary fix for #188, need to further investigate to know how broken cygwin support is.