### PR TITLE
Disable Ruby parallel installer on Windows.

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -74,7 +74,7 @@ let s:plug_buf = get(s:, 'plug_buf', -1)
 let s:mac_gui = has('gui_macvim') && has('gui_running')
 let s:is_win = has('win32') || has('win64')
 let s:py2 = has('python') && !s:is_win && !has('win32unix')
-let s:ruby = has('ruby') && (v:version >= 703 || v:version == 702 && has('patch374'))
+let s:ruby = has('ruby') && !s:is_win && (v:version >= 703 || v:version == 702 && has('patch374'))
 let s:nvim = has('nvim') && !s:is_win
 let s:me = resolve(expand('<sfile>:p'))
 let s:base_spec = { 'branch': 'master', 'frozen': 0 }


### PR DESCRIPTION
References #81