### PR TITLE
Ignore case for "<Plug>"

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -165,7 +165,7 @@ function! plug#end()
     if has_key(plug, 'on')
       let s:triggers[name] = { 'map': [], 'cmd': [] }
       for cmd in s:to_a(plug.on)
-        if cmd =~ '^<Plug>.\+'
+        if cmd =~? '^<Plug>.\+'
           if empty(mapcheck(cmd)) && empty(mapcheck(cmd, 'i'))
             call s:assoc(lod.map, cmd, name)
           endif


### PR DESCRIPTION
안녕하세요!

This is really just personal style, but I prefer my keys to be lowercase, hence this minimal change. 

Actually I wondered why it wouldn't autoload when I did `... { 'on': '<plug>(func)' }`. Could be unexpected for other users, too. :)