### PR TITLE
[RFC] Support Python 2.6+ & 3.0+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 1.9.2 # Test with vim-nox package on ubuntu
   - 1.9.3 # Test against python installer
   - 2.0.0
+  - 2.1.0 # Test against python3 installer
 
 before_script: |
   if [ $(ruby -e 'puts RUBY_VERSION') = 1.9.2 ]; then
@@ -17,6 +18,10 @@ before_script: |
       sudo apt-get update -y
       sudo apt-get install -y python2.7-dev
       ./configure --with-features=huge --enable-pythoninterp
+    elif [ $(ruby -e 'puts RUBY_VERSION') = 2.1.0 ]; then
+      sudo apt-get update -y
+      sudo apt-get install -y python3-dev
+      ./configure --with-features=huge --enable-python3interp
     else
       ./configure --with-features=huge --enable-rubyinterp
     fi

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A minimalist Vim plugin manager.
 - Easier to setup: Single file. No boilerplate code required.
 - Easier to use: Concise, intuitive syntax
 - [Super-fast][40/4] parallel installation/update
-  (with [+python][py] or [+ruby][rb] or [Neovim][nv])
+  (with [+python][py] or +python3 or [+ruby][rb] or [Neovim][nv])
 - On-demand loading for [faster startup time][startup-time]
 - Can review and rollback updates
 - Branch/tag support

--- a/test/test.vader
+++ b/test/test.vader
@@ -45,6 +45,8 @@ Execute (Print Interpreter Version):
     silent ruby puts 'Ruby: ' + RUBY_VERSION
   elseif has('python')
     silent python import sys; svi = sys.version_info; print 'Python: {}.{}.{}'.format(svi[0], svi[1], svi[2])
+  elseif has('python3')
+    silent python3 import sys; svi = sys.version_info; print('Python: {}.{}.{}'.format(svi[0], svi[1], svi[2]))
   endif
   redir END
   Log substitute(out, '\n', '', 'g')


### PR DESCRIPTION
* Minimal python code changes required.
* Now write temp file then use py(3)file.

Temp file is generated once on invoking update_python, then regenerated only on sucessful PlugUpgrade. I've tested on 3.1.2 & 3.4.0. Changes do not seem to have any impact on 2.6+ support from what I've seen.

@junegunn Do you know why my py3 (2.1.0) test run fails on that one test?