### PR TITLE
Specify a format when `git show` displays a commit

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -1934,7 +1934,7 @@ function! s:preview_commit()
   execute 'pedit' sha
   wincmd P
   setlocal filetype=git buftype=nofile nobuflisted
-  execute 'silent read !cd' s:shellesc(g:plugs[name].dir) '&& git show' sha
+  execute 'silent read !cd' s:shellesc(g:plugs[name].dir) '&& git show --pretty=medium' sha
   normal! gg"_dd
   wincmd p
 endfunction


### PR DESCRIPTION
If a user has a custom `format.pretty` set in their gitconfig, `git show` will use it. This can cause display issues when viewing a commit after a PlugUpdate.

If you use `git show --pretty=medium` the diff displays properly. Medium is the default format when a custom format isn't set by gitconfig.

Example gitconfig:

```
[format]
  pretty = format:%C(red)%h%Creset%C(yellow)%d%Creset %C(magenta)%an%Creset: %s %C(green)(%ar)%Creset
```

vim-plug display before this change:

![screenshot 2015-05-19 12 15 40](https://cloud.githubusercontent.com/assets/49571/7709905/287c75c8-fe2e-11e4-82d6-0b1dd931ea82.png)

vim-plug display after this change:

![screenshot 2015-05-19 12 16 41](https://cloud.githubusercontent.com/assets/49571/7709934/718e8eb8-fe2e-11e4-8ecc-cf0c0da6b15e.png)
