### PR TITLE
Bugfix of on-demand loading

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -440,7 +440,7 @@ function! s:add(repo, ...)
       call add(g:plugs_order, name)
     endif
     let g:plugs[name] = spec
-    let s:loaded[name] = 0
+    let s:loaded[name] = get(s:loaded, name, 0)
   catch
     return s:err(v:exception)
   endtry


### PR DESCRIPTION
Using `Plug 'scrooloose/nerdtree', { 'on':  'NERDTreeToggle' }` and reload `.vimrc`, nerdtree isn't contained `s:loaded` and cannot be rehooked.

So, I change this script for `s:loaded` containing on-demand loaded plugins when `.vimrc` is reloaded.