### PR TITLE
Remap window close to Q

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Reload .vimrc and `:PlugInstall` to install plugins.
 | `g:plug_shallow`    | 1                                 | Use shallow clone                                      |
 | `g:plug_window`     | `vertical topleft new`            | Command to open plug window                            |
 | `g:plug_url_format` | `https://git::@github.com/%s.git` | `printf` format to build repo URL                      |
+| `g:plug_quit`       | `q`                               | Key to close the window                                |
 
 ### Keybindings
 
@@ -106,7 +107,7 @@ Reload .vimrc and `:PlugInstall` to install plugins.
 - `S` - `PlugStatus`
 - `R` - Retry failed update or installation tasks
 - `U` - Update plugins in the selected range
-- `Q` - Close the window
+- `q` - Close the window
 - `:PlugStatus`
     - `L` - Load plugin
 - `:PlugDiff`

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Reload .vimrc and `:PlugInstall` to install plugins.
 - `S` - `PlugStatus`
 - `R` - Retry failed update or installation tasks
 - `U` - Update plugins in the selected range
-- `q` - Close the window
+- `Q` - Close the window
 - `:PlugStatus`
     - `L` - Load plugin
 - `:PlugDiff`

--- a/plug.vim
+++ b/plug.vim
@@ -604,7 +604,7 @@ function! s:prepare()
     silent %d _
   else
     call s:new_window()
-    nnoremap <silent> <buffer> Q  :if b:plug_preview==1<bar>pc<bar>endif<bar>echo<bar>q<cr>
+    execute 'nnoremap <silent> <buffer> ' . get(g:, 'plug_quit', 'q') . ' :if b:plug_preview==1<bar>pc<bar>endif<bar>echo<bar>q<cr>'
     nnoremap <silent> <buffer> R  :silent! call <SID>retry()<cr>
     nnoremap <silent> <buffer> D  :PlugDiff<cr>
     nnoremap <silent> <buffer> S  :PlugStatus<cr>

--- a/plug.vim
+++ b/plug.vim
@@ -604,7 +604,7 @@ function! s:prepare()
     silent %d _
   else
     call s:new_window()
-    nnoremap <silent> <buffer> q  :if b:plug_preview==1<bar>pc<bar>endif<bar>echo<bar>q<cr>
+    nnoremap <silent> <buffer> Q  :if b:plug_preview==1<bar>pc<bar>endif<bar>echo<bar>q<cr>
     nnoremap <silent> <buffer> R  :silent! call <SID>retry()<cr>
     nnoremap <silent> <buffer> D  :PlugDiff<cr>
     nnoremap <silent> <buffer> S  :PlugStatus<cr>


### PR DESCRIPTION
Remap `q` to `Q`, as `q` requires and extra key press, and it matches the capitalized scheme of the other keys. Feel free to map to something else, `Q` was just a suggestion as its unlikely someone would use `ex` mode in a plugin buffer. :smiley: 