### PR TITLE
PlugDiff mappings

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -1904,6 +1904,8 @@ function! s:preview_commit()
   setlocal filetype=git buftype=nofile nobuflisted
   execute 'silent read !cd' s:shellesc(g:plugs[name].dir) '&& git show --pretty=medium' sha
   normal! gg"_dd
+  setlocal nomodifiable
+  nnoremap <silent> <buffer> q :q<cr>
   wincmd p
 endfunction
 


### PR DESCRIPTION
Hoping you will be interested in this (obviously) and maybe try it out a bit (I've only been using it for a day).

This introduces some new mappings for `:PlugDiff`:

`J` and `K` can be used from the diff buffer to scroll the commit preview window without having to switch to it.

`<C-N>` and `<C-P>` can be used to jump straight to commit lines (sorta like jumping to files in fugitive's commit window).

I've also made the commit window `unmodifiable` and mapped `q` to `:quit` (while inside it).

This PR introduces a `s:buffocus()` utility function.  This is used to ensure that the `J` and `K` mappings will only ever scroll the commit preview window.  If you would like me to ditch it in favour of `wincmd p`--or just change its location in the file--I will oblige.

I've also documented the `<CR>` and `o` mappings for `:PlugDiff`.

If you're willing to accept this PR, I'm happy to make any other changes or edits but otherwise, thanks for this amazing plugin manager.