### PR TITLE
Add local plugin usage to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Plug 'tpope/vim-fireplace', { 'for': 'clojure' }
 " Using git URL
 Plug 'https://github.com/junegunn/vim-github-dashboard.git'
 
+" Local plugin
+Plug '/my/local/vim/plugin'
+
 " Plugin options
 Plug 'nsf/gocode', { 'tag': 'v.20150303', 'rtp': 'vim' }
 


### PR DESCRIPTION
This was added to the README in
466d1839b37c174a66b329fadce2512b0a2ffa5e, but for some reason the
functionality is still there but it’s no longer documented in the
README.