### PR TITLE
Refactor Python Command & .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,49 @@
 language: ruby
 rvm:
   - 1.8.7
-  - 1.9.2 # Test with vim-nox package on ubuntu
-  - 1.9.3 # Test against python installer
   - 2.0.0
-  - 2.1.0 # Test against python3 installer
-
-before_script: |
-  sudo apt-get update -y
-  if [ $(ruby -e 'puts RUBY_VERSION') = 1.9.2 ]; then
-    sudo apt-get install -y vim-nox
-    sudo ln -s /usr/bin/vim /usr/local/bin/vim
-  else
-    git clone --depth 1 https://github.com/vim/vim
-    cd vim
-    if [ $(ruby -e 'puts RUBY_VERSION') = 1.9.3 ]; then
-      sudo apt-get install -y python2.7-dev
-      ./configure --disable-gui --with-features=huge --enable-pythoninterp
-    elif [ $(ruby -e 'puts RUBY_VERSION') = 2.1.0 ]; then
-      sudo apt-get install -y python3-dev
-      ./configure --disable-gui --with-features=huge --enable-python3interp
-    else
-      ./configure --disable-gui --with-features=huge --enable-rubyinterp
-    fi
-    make
-    sudo make install
-    cd -
-  fi
-
+env:
+  - ENV=nox
+  - ENV=python
+  - ENV=python3
+  - ENV=ruby
+matrix:
+  exclude:
+    - rvm: 2.0.0
+  include:
+    - rvm: 2.0.0
+      env: ENV=ruby
+install: |
   git config --global user.email "you@example.com"
   git config --global user.name "Your Name"
+  sudo apt-get update -y
 
-script: |
-  test/run !
+  if [ "$ENV" == "nox" ]; then
+    sudo apt-get install -y vim-nox
+    sudo ln -s /usr/bin/vim /usr/local/bin/vim
+    return
+  fi
+
+  C_OPTS="--with-features=huge --disable-gui "
+  case "$ENV" in
+    python)
+      PACKS=python2.7-dev
+      C_OPtS+=--enable-pythoninterp
+      ;;
+    python3)
+      PACKS=python3-dev
+      C_OPtS+=--enable-python3interp
+      ;;
+    ruby)
+      C_OPTS+=--enable-rubyinterp
+      ;;
+  esac
+
+  sudo apt-get install -y $PACKS
+  git clone --depth 1 https://github.com/vim/vim
+  cd vim
+  ./configure $C_OPTS
+  make
+  sudo make install
+  cd -
+script: test/run !


### PR DESCRIPTION
A few highlights:
* ~~Change from time.sleep to using a thread that blocks & join it. Should reduce cpu polling problem and make it faster.~~
* A lot of style improvements in the Command class and surrounding code.
* Change travis to use env instead of many ruby versions. Makes it easier to see what build broke as env can be 'nox', 'python', 'python3', or 'ruby'. Also, I think the script reads easier.

Need to spend more time investigating the time.sleep alternative. For now, I'll just increase the sleep to reduce load.