### PR TITLE
Add install directions for using neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
     https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 ```
 
+If you're using neovim:
+```sh
+curl -fLo ~/.config/nvim/autoload/plug.vim --create-dirs \
+    https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+```
+
 ###### Windows
 
 ```powershell

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
     https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 ```
 
-If you're using neovim:
+###### Neovim
+
 ```sh
 curl -fLo ~/.config/nvim/autoload/plug.vim --create-dirs \
     https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim


### PR DESCRIPTION
Neovim's autoload directory path is now considerably different from vim's.