### PR TITLE
Add install directions for using neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
     https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 ```
 
+###### Neovim
+
+```sh
+curl -fLo ~/.config/nvim/autoload/plug.vim --create-dirs \
+    https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+```
+
 ###### Windows
 
 ```powershell


### PR DESCRIPTION
Neovim's autoload directory path is now considerably different from vim's.

Got impatient, squashed patch myself.