### PR TITLE
Prepend cd to commands.

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -1092,7 +1092,8 @@ G_LOG_PROB = 1.0 / int(vim.eval('s:update.threads'))
 G_STOP = thr.Event()
 
 class PlugError(Exception):
-  pass
+  def __init__(self, msg):
+    self.msg = msg
 class CmdTimedOut(PlugError):
   pass
 class CmdFailed(PlugError):
@@ -1166,7 +1167,8 @@ class Buffer(object):
 class Command(object):
   def __init__(self, cmd, cmd_dir=None, timeout=60, cb=None, clean=None):
     self.cmd = cmd
-    self.cmd_dir = cmd_dir
+    if cmd_dir:
+      self.cmd = 'cd {0} && {1}'.format(cmd_dir, self.cmd)
     self.timeout = timeout
     self.callback = cb if cb else (lambda msg: None)
     self.clean = clean if clean else (lambda: None)
@@ -1216,7 +1218,7 @@ class Command(object):
 
     try:
       tfile = tempfile.NamedTemporaryFile(mode='w+b')
-      self.proc = subprocess.Popen(self.cmd, cwd=self.cmd_dir, stdout=tfile,
+      self.proc = subprocess.Popen(self.cmd, stdout=tfile,
                                    stderr=subprocess.STDOUT, shell=True,
                                    preexec_fn=os.setsid)
       thrd = thr.Thread(target=(lambda proc: proc.wait()), args=(self.proc,))
@@ -1283,7 +1285,7 @@ class Plugin(object):
         with self.lock:
           thread_vim_command("let s:update.new['{0}'] = 1".format(self.name))
     except PlugError as exc:
-      self.write(Action.ERROR, self.name, [str(exc)])
+      self.write(Action.ERROR, self.name, exc.msg)
     except KeyboardInterrupt:
       G_STOP.set()
       self.write(Action.ERROR, self.name, ['Interrupted!'])


### PR DESCRIPTION
Weird bug on msys2, easily fixed by just using cd instead of cwd arg.

The PlugError change is unrelated. Just makes the behavior more consistent, should have been a bit more careful re exceptions.