### PR TITLE
Only highlight vim-plug buffers if syntax highlighting is enabled

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -645,7 +645,9 @@ function! s:prepare()
   silent! unmap <buffer> X
   setlocal buftype=nofile bufhidden=wipe nobuflisted noswapfile nowrap cursorline modifiable
   setf vim-plug
-  call s:syntax()
+  if exists('g:syntax_on')
+    call s:syntax()
+  endif
 endfunction
 
 function! s:assign_name()


### PR DESCRIPTION
Previously, syntax highlighting was turned on unconditionally in the buffers opened by commands such as `:PlugUpdate`. With this commit, highlighting is not applied if the user has disabled syntax highlighting
by calling `syntax off` after `call plug#end()` in their `vimrc`.