### PR TITLE
Fix #397: clarify in docs that GitHub is the default plugin source

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,12 @@ Add a vim-plug section to your `~/.vimrc` (or `~/.config/nvim/init.vim` for Neov
 call plug#begin('~/.vim/plugged')
 
 " Make sure you use single quotes
-Plug 'junegunn/seoul256.vim'
+
+" Shorthand notation; fetches https://github.com/junegunn/vim-easy-align
 Plug 'junegunn/vim-easy-align'
+
+" Any valid git URL is allowed
+Plug 'https://github.com/junegunn/vim-github-dashboard.git'
 
 " Group dependencies, vim-snippets depends on ultisnips
 Plug 'SirVer/ultisnips' | Plug 'honza/vim-snippets'
@@ -72,9 +76,6 @@ Plug 'SirVer/ultisnips' | Plug 'honza/vim-snippets'
 " On-demand loading
 Plug 'scrooloose/nerdtree', { 'on':  'NERDTreeToggle' }
 Plug 'tpope/vim-fireplace', { 'for': 'clojure' }
-
-" Using git URL
-Plug 'https://github.com/junegunn/vim-github-dashboard.git'
 
 " Using a non-master branch
 Plug 'rdnetto/YCM-Generator', { 'branch': 'stable' }

--- a/plug.vim
+++ b/plug.vim
@@ -11,8 +11,12 @@
 "   call plug#begin('~/.vim/plugged')
 "
 "   " Make sure you use single quotes
-"   Plug 'junegunn/seoul256.vim'
+"
+"   " Shorthand notation; fetches https://github.com/junegunn/vim-easy-align
 "   Plug 'junegunn/vim-easy-align'
+"
+"   " Any valid git URL is allowed
+"   Plug 'https://github.com/junegunn/vim-github-dashboard.git'
 "
 "   " Group dependencies, vim-snippets depends on ultisnips
 "   Plug 'SirVer/ultisnips' | Plug 'honza/vim-snippets'
@@ -20,9 +24,6 @@
 "   " On-demand loading
 "   Plug 'scrooloose/nerdtree', { 'on':  'NERDTreeToggle' }
 "   Plug 'tpope/vim-fireplace', { 'for': 'clojure' }
-"
-"   " Using git URL
-"   Plug 'https://github.com/junegunn/vim-github-dashboard.git'
 "
 "   " Using a non-master branch
 "   Plug 'rdnetto/YCM-Generator', { 'branch': 'stable' }
@@ -40,7 +41,21 @@
 "   call plug#end()
 "
 " Then reload .vimrc and :PlugInstall to install plugins.
-" Visit https://github.com/junegunn/vim-plug for more information.
+"
+" Plug options:
+"
+"| Option                  | Description                                      |
+"| ----------------------- | ------------------------------------------------ |
+"| `branch`/`tag`/`commit` | Branch/tag/commit of the repository to use       |
+"| `rtp`                   | Subdirectory that contains Vim plugin            |
+"| `dir`                   | Custom directory for the plugin                  |
+"| `as`                    | Use different name for the plugin                |
+"| `do`                    | Post-update hook (string or funcref)             |
+"| `on`                    | On-demand loading: Commands or `<Plug>`-mappings |
+"| `for`                   | On-demand loading: File types                    |
+"| `frozen`                | Do not update unless explicitly specified        |
+"
+" More information: https://github.com/junegunn/vim-plug
 "
 "
 " Copyright (c) 2015 Junegunn Choi


### PR DESCRIPTION
Made changes discussed in #397. Also, put a copy of the Plug options table in the plug.vim file. I think this was suggested previously by a few people that just wanted a quick reminder, doesn't take up too much space.

@junegunn Comments?