### PR TITLE
Avoid multiple `syntax enable` during Vim startup

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -248,7 +248,9 @@ function! plug#end()
   call s:reorg_rtp()
   filetype plugin indent on
   if has('vim_starting')
-    syntax enable
+    if has('syntax') && !exists('g:syntax_on')
+      syntax enable
+    end
   else
     call s:reload()
   endif

--- a/test/workflow.vader
+++ b/test/workflow.vader
@@ -941,7 +941,7 @@ Execute (Filetype-based on-demand loading):
   AssertEqual ['xxx/ftdetect', 'xxx/after/ftdetect'], g:xxx
 
   setf xxx
-  AssertEqual ['xxx/ftdetect', 'xxx/after/ftdetect', 'xxx/plugin', 'xxx/after/plugin', 'xxx/syntax', 'xxx/after/syntax', 'xxx/ftplugin', 'xxx/after/ftplugin', 'xxx/indent', 'xxx/after/indent', 'xxx/syntax', 'xxx/after/syntax'], g:xxx
+  AssertEqual ['xxx/ftdetect', 'xxx/after/ftdetect', 'xxx/plugin', 'xxx/after/plugin', 'xxx/syntax', 'xxx/after/syntax', 'xxx/ftplugin', 'xxx/after/ftplugin', 'xxx/indent', 'xxx/after/indent'], g:xxx
 
   " syntax/xxx.vim and after/syntax/xxx.vim should not be loaded (#410)
   setf yyy


### PR DESCRIPTION
If one runs `vim +PlugUpdate` there are two calls to `syntax enable`; one from `plug#end()` in your vimrc and another from the `PlugUpdate` command itself. It seems that when you use `+PlugUpdate` via the CLI that *both* calls to `plug#end()` happen while `has('vim_starting')` is true. This causes a minor issue where syntax highlighting (for the plug.vim itself) is lost when `PlugUpdate` finishes running.

There is a gif I found in an [unrelated issue](https://github.com/junegunn/vim-plug/issues/278#issuecomment-138683431) that shows this in action.

With this patch syntax highlighting is not lost when `PlugUpdate` finishes.