### PR TITLE
Refactor duplicate logic in installers

### DIFF
--- a/test/workflow.vader
+++ b/test/workflow.vader
@@ -1296,15 +1296,20 @@ Execute (#221 Shallow-clone disabled by tag):
   cd -
 
 Execute (Commit hash support):
+  " Get goyo back to master
+  call plug#begin(g:temp_plugged)
+  Plug 'junegunn/goyo.vim'
+  call plug#end()
+  PlugUpdate
+
   call plug#begin(g:temp_plugged)
   Plug 'junegunn/goyo.vim',  { 'commit': 'ffffffff' }
   Plug 'junegunn/vim-emoji', { 'commit': '9db7fcfee0d90dafdbcb7a32090c0a9085eb054a' }
   call plug#end()
   PlugUpdate
   Log getline(1, '$')
-  AssertEqual ['x Checking out fffffff of goyo.vim ... Error',
-              \'    error: pathspec ''ffffffff'' did not match any file(s) known to git.',
-              \'- Checking out 9db7fcf of vim-emoji ... OK'], getline(5, 7)
+  AssertEqual 'x goyo.vim: error: pathspec ''ffffffff'' did not match any file(s) known to git.', getline(5)
+  AssertEqual 0, stridx(getline(6), '- vim-emoji: HEAD is now at 9db7fcf...')
 
   let hash = system(printf('cd %s && git rev-parse HEAD', g:plugs['vim-emoji'].dir))[:-2]
   AssertEqual '9db7fcfee0d90dafdbcb7a32090c0a9085eb054a', hash


### PR DESCRIPTION
This commit extracts duplicate logic out of three installers; vimscript, ruby, and python.

Summary:
- The steps after `git fetch` or `git clone` is now done in Vimscript.

Pros.
- Better maintainability
- Easier to add/extend the features
- Fixes a bug when 'commit' option is used, submodules are updated
  before the designated commit is checked out

Cons.
- The whole process takes slightly longer due to lost parallelism after pull
- Especially, submodule updates are not parallelized
    - However, this shouldn't matter much in practice as there are very
      few plugins that heavily rely on submodules
- ~~No streaming output (or timeout) during submodule update~~