### PR TITLE
support do vim command

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,13 @@ Plug 'Shougo/vimproc.vim', { 'do': 'make' }
 Plug 'Valloric/YouCompleteMe', { 'do': './install.py' }
 ```
 
+If you need to execute Vim's command, you can pass the command name with a
+leading `:`.
+
+```
+Plug 'Shougo/deoplete.nvim', {'do':':UpdateRemotePlugins'}
+```
+
 If you need more control, you can pass a reference to a Vim function that
 takes a single argument.
 

--- a/plug.vim
+++ b/plug.vim
@@ -723,10 +723,15 @@ function! s:do(pull, force, todo)
       let type = type(spec.do)
       if type == s:TYPE.string
         try
-          " FIXME: Escaping is incomplete. We could use shellescape with eval,
-          "        but it won't work on Windows.
-          let g:_plug_do = '!'.escape(spec.do, '#!%')
-          execute "normal! :execute g:_plug_do\<cr>\<cr>"
+          if spec.do =~? '^:'
+            let g:_plug_do = spec.do[1:]
+            execute g:_plug_do
+          else
+            " FIXME: Escaping is incomplete. We could use shellescape with eval,
+            "        but it won't work on Windows.
+            let g:_plug_do = '!'.escape(spec.do, '#!%')
+            execute "normal! :execute g:_plug_do\<cr>\<cr>"
+          endif
         finally
           if v:shell_error
             let error = 'Exit status: ' . v:shell_error


### PR DESCRIPTION
<!-- ## Before Submitting

- You made sure the existing tests/travis build works.
- You made sure any new features were tested where appropriate.
- You checked a similar feature wasn't already turned down by searching issues & PRs.
-->

For post-update hooks, If you need to execute Vim's command, you can pass the command name with a leading `:`.
```
Plug 'Shougo/deoplete.nvim', {'do':':UpdateRemotePlugins'}
```
