### PR TITLE
Reset colors for git show

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -2057,7 +2057,7 @@ function! s:preview_commit()
   execute 'pedit' sha
   wincmd P
   setlocal filetype=git buftype=nofile nobuflisted modifiable
-  execute 'silent read !cd' s:shellesc(g:plugs[name].dir) '&& git show --pretty=medium' sha
+  execute 'silent read !cd' s:shellesc(g:plugs[name].dir) '&& git show --no-color --pretty=medium' sha
   normal! gg"_dd
   setlocal nomodifiable
   nnoremap <silent> <buffer> q :q<cr>


### PR DESCRIPTION
Problem: When the user has non default color settings for git show,
         the output is full of terminal escaping sequences
Solution: Add `--no-color` to the `git show` command