### PR TITLE
Make PlugInstall!, PlugUpdate! trigger post-fetch checkout and submodule update

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -955,7 +955,7 @@ function! s:update_finish()
   endif
   if s:switch_in()
     call append(3, '- Updating ...') | 4
-    for [name, spec] in items(filter(copy(s:update.all), 'index(s:update.errors, v:key) < 0 && (s:update.pull || has_key(s:update.new, v:key))'))
+    for [name, spec] in items(filter(copy(s:update.all), 'index(s:update.errors, v:key) < 0 && (s:update.force || s:update.pull || has_key(s:update.new, v:key))'))
       let pos = s:logpos(name)
       if !pos
         continue
@@ -973,7 +973,7 @@ function! s:update_finish()
               \. (has_key(s:update.new, name) ? '' : ('&& git merge --ff-only origin/'.branch.' 2>&1')), spec.dir)
       endif
       if !v:shell_error && filereadable(spec.dir.'/.gitmodules') &&
-            \ (has_key(s:update.new, name) || s:is_updated(spec.dir))
+            \ (s:update.force || has_key(s:update.new, name) || s:is_updated(spec.dir))
         call s:log4(name, 'Updating submodules. This may take a while.')
         let out .= s:bang('git submodule update --init --recursive 2>&1', spec.dir)
       endif

--- a/test/run
+++ b/test/run
@@ -27,6 +27,8 @@ clone_repos() (
   done
   clone https://github.com/vim-scripts/beauty256.git vim-scripts/beauty256 &
   clone https://github.com/junegunn/fzf.git fzf &
+  clone https://github.com/yous/subsubmodule.git yous/subsubmodule && \
+    (cd yous/subsubmodule && git submodule update --init --recursive &) &
   wait
 
   clone junegunn/vim-emoji jg/vim-emoji

--- a/test/test.vader
+++ b/test/test.vader
@@ -51,6 +51,18 @@ Execute (Initialize test environment):
     let &rtp = g:base_rtp
   endfunction
 
+  function! GitBranch(repo)
+    return system(printf('cd %s && git rev-parse --abbrev-ref HEAD', g:plugs[a:repo].dir))[:-2]
+  endfunction
+
+  function! GitTag(repo)
+    return system(printf('cd %s && git describe --tags', g:plugs[a:repo].dir))[:-2]
+  endfunction
+
+  function! GitCommit(repo)
+    return system(printf('cd %s && git rev-parse HEAD', g:plugs[a:repo].dir))[:-2]
+  endfunction
+
   source $PLUG_SRC
 
 Execute (Print Interpreter Version):

--- a/test/workflow.vader
+++ b/test/workflow.vader
@@ -721,6 +721,9 @@ Execute (On install):
   call plug#begin()
   Plug 'junegunn/vim-easy-align', { 'do': 'touch installed' }
   Plug 'junegunn/vim-pseudocl'
+  Plug 'junegunn/seoul256.vim'
+  Plug 'junegunn/goyo.vim'
+  Plug 'yous/subsubmodule'
   call plug#end()
 
   silent PlugInstall
@@ -730,11 +733,16 @@ Execute (On install):
     \ 'vim-easy-align/installed should exist'
   Assert !filereadable(g:plugs['vim-pseudocl'].dir.'/installed'),
     \ 'vim-pseudocl/installed should not exist'
+  AssertEqual ' ', system('cd '.g:plugs['subsubmodule'].dir.' && git submodule status')[0],
+    \ 'subsubmodule/subsubmodule should be initialized'
 
 Execute (On update):
   call plug#begin()
   Plug 'junegunn/vim-easy-align', { 'do': 'touch updated' }
   Plug 'junegunn/vim-pseudocl', { 'do': 'touch updated' }
+  Plug 'junegunn/seoul256.vim'
+  Plug 'junegunn/goyo.vim'
+  Plug 'yous/subsubmodule'
   call plug#end()
 
   " New commits on remote
@@ -752,44 +760,68 @@ Execute (On update):
 Execute (When already installed):
   call plug#begin()
   Plug 'junegunn/vim-easy-align', { 'do': 'touch installed2' }
-  Plug 'junegunn/vim-pseudocl', { 'do': 'touch installed2' }
+  Plug 'junegunn/vim-pseudocl', { 'commit': '7f8cd78' }
+  Plug 'junegunn/seoul256.vim', { 'branch': 'no-t_co' }
+  Plug 'junegunn/goyo.vim', { 'tag': '1.5.3' }
+  Plug 'yous/subsubmodule'
   call plug#end()
 
   PlugInstall
   q
   Assert !filereadable(g:plugs['vim-easy-align'].dir.'/installed2'),
     \ 'vim-easy-align/installed2 should not exist'
-  Assert !filereadable(g:plugs['vim-pseudocl'].dir.'/installed2'),
-    \ 'vim-pseudocl/installed2 should not exist'
+  AssertNotEqual '7f8cd78cb1fe52185b98b16a3749811f0cc508af', GitCommit('vim-pseudocl')
+  AssertNotEqual 'no-t_co', GitBranch('seoul256.vim')
+  AssertNotEqual '1.5.3', GitTag('goyo.vim')
 
 Execute (PlugInstall!):
   silent PlugInstall!
   q
   Assert filereadable(g:plugs['vim-easy-align'].dir.'/installed2'),
     \ 'vim-easy-align/installed2 should exist'
-  Assert filereadable(g:plugs['vim-pseudocl'].dir.'/installed2'),
-    \ 'vim-pseudocl/installed2 should exist'
+  AssertEqual '7f8cd78cb1fe52185b98b16a3749811f0cc508af', GitCommit('vim-pseudocl')
+  AssertEqual 'no-t_co', GitBranch('seoul256.vim')
+  AssertEqual '1.5.3', GitTag('goyo.vim')
+
+Execute (When submodules are not initialized):
+  call system(printf('cd %s && git submodule deinit subsubmodule', g:plugs['subsubmodule'].dir))
+
+  silent PlugInstall!
+  q
+
+  AssertEqual ' ', system(printf('cd %s && git submodule status', g:plugs['subsubmodule'].dir))[0],
+    \ 'subsubmodule/subsubmodule should be initialized'
 
 Execute (When already updated):
   call plug#begin()
   Plug 'junegunn/vim-easy-align', { 'do': 'touch updated2' }
-  Plug 'junegunn/vim-pseudocl', { 'do': 'touch updated2' }
+  Plug 'junegunn/vim-pseudocl', { 'commit': 'dd507ca' }
+  Plug 'junegunn/seoul256.vim', { 'branch': 'master' }
+  Plug 'junegunn/goyo.vim', { 'tag': '1.6.0' }
+  Plug 'yous/subsubmodule'
   call plug#end()
 
   PlugUpdate
   q
   Assert !filereadable(g:plugs['vim-easy-align'].dir.'/updated2'),
     \ 'vim-easy-align/updated2 should not exist'
-  Assert !filereadable(g:plugs['vim-pseudocl'].dir.'/updated2'),
-    \ 'vim-pseudocl/updated2 should not exist'
+  AssertEqual 'dd507ca0d5f3fdf0d522558cc5ecffdabf824469', GitCommit('vim-pseudocl')
+  AssertEqual 'master', GitBranch('seoul256.vim')
+  AssertEqual '1.6.0', GitTag('goyo.vim')
 
 Execute (PlugUpdate!):
   silent PlugUpdate!
   q
   Assert filereadable(g:plugs['vim-easy-align'].dir.'/updated2'),
     \ 'vim-easy-align/updated2 should exist'
-  Assert filereadable(g:plugs['vim-pseudocl'].dir.'/updated2'),
-    \ 'vim-pseudocl/updated2 should exist'
+
+Execute (When submodules are not initialized):
+  call system(printf('cd %s && git submodule deinit subsubmodule', g:plugs['subsubmodule'].dir))
+
+  silent PlugUpdate!
+  q
+  AssertEqual ' ', system(printf('cd %s && git submodule status', g:plugs['subsubmodule'].dir))[0],
+    \ 'subsubmodule/subsubmodule should be initialized'
 
 Execute (Using Funcref):
   function! PlugUpdated(info)


### PR DESCRIPTION
<!-- ## Before Submitting

- You made sure the existing tests/travis build works.
- You made sure any new features were tested where appropriate.
- You checked a similar feature wasn't already turned down by searching issues & PRs.
-->
Using YouCompleteMe, I faced some cases that `PlugInstall` clones YouCompleteMe successfully, but submodules are not cloned by interrupt or some other failures. Then even if I do `PlugInstall!` or `PlugUpdate!`, vim-plug doesn't clone submodules, so I had to `cd ~/.vim/plugged/YouCompleteMe && git submodule update --init --recursive` either `rm -rf ~/.vim/plugged/YouComplete` followed by `PlugInstall` again.

This pull request makes `PlugInstall!` and `PlugUpdate!` clone submodules, but I'm not sure it's okay to make `filter` to include every item with `s:update.force`.