### PR TITLE
Support wildcards in tag option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ Plug 'tpope/vim-fireplace', { 'for': 'clojure' }
 " Using a non-master branch
 Plug 'rdnetto/YCM-Generator', { 'branch': 'stable' }
 
+" Using a tagged release; wildcard allowed (requires git 1.9.2 or above)
+Plug 'fatih/vim-go', { 'tag': '*' }
+
 " Plugin options
 Plug 'nsf/gocode', { 'tag': 'v.20150303', 'rtp': 'vim' }
 

--- a/plug.vim
+++ b/plug.vim
@@ -28,6 +28,9 @@
 "   " Using a non-master branch
 "   Plug 'rdnetto/YCM-Generator', { 'branch': 'stable' }
 "
+"   " Using a tagged release; wildcard allowed (requires git 1.9.2 or above)
+"   Plug 'fatih/vim-go', { 'tag': '*' }
+"
 "   " Plugin options
 "   Plug 'nsf/gocode', { 'tag': 'v.20150303', 'rtp': 'vim' }
 "
@@ -966,8 +969,17 @@ function! s:update_finish()
         call s:log4(name, 'Checking out '.spec.commit)
         let out = s:checkout(spec)
       elseif has_key(spec, 'tag')
-        call s:log4(name, 'Checking out '.spec.tag)
-        let out = s:system('git checkout -q '.s:esc(spec.tag).' 2>&1', spec.dir)
+        let tag = spec.tag
+        if tag =~ '\*'
+          let tags = s:lines(s:system('git tag --list '.string(tag).' --sort -version:refname 2>&1', spec.dir))
+          if !v:shell_error && !empty(tags)
+            let tag = tags[0]
+            call s:log4(name, printf('Latest tag for %s -> %s', spec.tag, tag))
+            call append(3, '')
+          endif
+        endif
+        call s:log4(name, 'Checking out '.tag)
+        let out = s:system('git checkout -q '.s:esc(tag).' 2>&1', spec.dir)
       else
         let branch = s:esc(get(spec, 'branch', 'master'))
         call s:log4(name, 'Merging origin/'.branch)
@@ -2227,4 +2239,3 @@ endif
 
 let &cpo = s:cpo_save
 unlet s:cpo_save
-

--- a/test/run
+++ b/test/run
@@ -104,6 +104,7 @@ select_vim() {
 clone_repos
 prepare
 
+git --version
 VIM=$(select_vim)
 echo "Selected Vim: $VIM"
 if [ "$1" = '!' ]; then

--- a/test/workflow.vader
+++ b/test/workflow.vader
@@ -1424,3 +1424,16 @@ Execute (#371 - 'as' option):
   AssertEqual ['yogo'], sort(keys(g:plugs))
   AssertEqual '/tmp/gogo/', g:plugs.yogo.dir
 
+Execute (#427 - Tag option with wildcard (requires git 1.9.2 or above)):
+  if str2nr(split(split(system('git --version'))[-1], '\.')[0]) < 2
+    Log 'tag with wildcard requires git 1.9.2 or above'
+  else
+    call plug#begin()
+    Plug 'junegunn/vim-easy-align', { 'tag': '2.9.*' }
+    call plug#end()
+    PlugInstall!
+    Log getline(1, '$')
+    AssertExpect! '- Latest tag for 2.9.* -> 2.9.7 (vim-easy-align)', 1
+    q
+    AssertEqual '2.9.7', GitTag('vim-easy-align')
+  endif


### PR DESCRIPTION
Close #427

- No manual parsing of the expression; just uses `git tag --list <pattern>` for wildcard expansion
- *ProTip*: `{ 'tag: '*' }` will point to the latest tagged release
- Requires git 1.9.2 or above (`error: unknown option 'sort'`)
    - Are we fine with this? I think it's okay, as it's probably not going to be the most popular option.
    - So the test case fails on travis-ci as it comes with git 1.8.5.6.
         - We can either install the latest git using ppa, or just skip the test if the version requirement is not met
         - Since I'd like to make sure that vim-plug is still functional with older versions of git and Vim, so let's go with the latter.

/cc @vilhalmer