### PR TITLE
Fix install plugins in Cygwin or MSYS2 vim with enabled git core.auto…

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -931,7 +931,7 @@ function! s:update_impl(pull, force, args) abort
   silent! redraw
 
   let s:clone_opt = get(g:, 'plug_shallow', 1) ?
-        \ '--depth 1' . (s:git_version_requirement(1, 7, 10) ? ' --no-single-branch' : '') : ''
+        \ '--depth 1' . (s:git_version_requirement(1, 7, 10) ? ' --no-single-branch' : '') . (has('win32unix') ? ' -c core.autocrlf=false' : '') : ''
 
   " Python version requirement (>= 2.7)
   if python && !has('python3') && !ruby && !s:nvim && s:update.threads > 1


### PR DESCRIPTION
<!-- ## Before Submitting

- You made sure the existing tests/travis build works.
- You made sure any new features were tested where appropriate.
- You checked a similar feature wasn't already turned down by searching issues & PRs.
-->

Vim from Cygwin or MSYS2 require LF line endings in plugins. But option core.autocrlf for Git for Windows usually is true and git converts LF to CRLF. This PR disabled core.autocrlf option for git.
