### PR TITLE
Silence :delete commands

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -1048,14 +1048,14 @@ function! s:update_finish()
       if v:shell_error
         call add(s:update.errors, name)
         call s:regress_bar()
-        execute pos 'd _'
+        silent execute pos 'd _'
         call append(4, msg) | 4
       elseif !empty(out)
         call setline(pos, msg)
       endif
       redraw
     endfor
-    4 d _
+    silent 4 d _
     call s:do(s:update.pull, s:update.force, filter(copy(s:update.all), 'index(s:update.errors, v:key) < 0 && has_key(v:val, "do")'))
     call s:finish(s:update.pull)
     call setline(1, 'Updated. Elapsed time: ' . split(reltimestr(reltime(s:update.start)))[0] . ' sec.')
@@ -1172,7 +1172,7 @@ function! s:log(bullet, name, lines)
   if s:switch_in()
     let pos = s:logpos(a:name)
     if pos > 0
-      execute pos 'd _'
+      silent execute pos 'd _'
       if pos > winheight('.')
         let pos = 4
       endif


### PR DESCRIPTION
Add `:silence` to all `:delete` commands to avoid filling up the message history with *"1 line less"* messages.

---

I noticed this after `:PlugUpdate`, so silencing the `:delete` in `s:log()` would have been enough. But I found 2 other unsilenced occurences and couldn't come up with a reason why they shouldn't be silenced as well.