### PR TITLE
Fixing E684 when VisualHostKey is enabled for ssh

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -1089,7 +1089,7 @@ function! s:job_handler(job_id, data, event) abort
 
   if a:event == 'stdout'
     let complete = empty(a:data[-1])
-    let lines = map(filter(a:data, 'len(v:val) > 0'), 'split(v:val, "[\r\n]")[-1]')
+    let lines = map(filter(a:data, 'v:val =~ "[^\r\n]"'), 'split(v:val, "[\r\n]")[-1]')
     call extend(self.lines, lines)
     let self.result = join(self.lines, "\n")
     if !complete


### PR DESCRIPTION
Having VisualHostKey enabled for ssh can cause lines containing a single "^M" character to appear in the git output, which causes E684 to be thrown if not filtered out.

This just changes a filter to ignore any sort of newline characters so that the following split should never return an empty list.