### PR TITLE
Add option to disable automatic submodule pulling

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -57,6 +57,7 @@
 "| `on`                    | On-demand loading: Commands or `<Plug>`-mappings |
 "| `for`                   | On-demand loading: File types                    |
 "| `frozen`                | Do not update unless explicitly specified        |
+"| `submod`                | Recursively fetch sub-repositories (submodules)  |              |
 "
 " More information: https://github.com/junegunn/vim-plug
 "
@@ -99,7 +100,7 @@ let s:mac_gui = has('gui_macvim') && has('gui_running')
 let s:is_win = has('win32') || has('win64')
 let s:nvim = has('nvim') && exists('*jobwait') && !s:is_win
 let s:me = resolve(expand('<sfile>:p'))
-let s:base_spec = { 'branch': 'master', 'frozen': 0 }
+let s:base_spec = { 'branch': 'master', 'frozen': 0, 'submod': 1 }
 let s:TYPE = {
 \   'string':  type(''),
 \   'list':    type([]),
@@ -1042,7 +1043,7 @@ function! s:update_finish()
         let out = s:system('git checkout -q '.branch.' 2>&1'
               \. (has_key(s:update.new, name) ? '' : ('&& git merge --ff-only origin/'.branch.' 2>&1')), spec.dir)
       endif
-      if !v:shell_error && filereadable(spec.dir.'/.gitmodules') &&
+      if !v:shell_error && filereadable(spec.dir.'/.gitmodules') && get(spec, 'submod', 1) &&
             \ (s:update.force || has_key(s:update.new, name) || s:is_updated(spec.dir))
         call s:log4(name, 'Updating submodules. This may take a while.')
         let out .= s:bang('git submodule update --init --recursive 2>&1', spec.dir)
@@ -2075,6 +2076,7 @@ endfunction
 function! s:upgrade_specs()
   for spec in values(g:plugs)
     let spec.frozen = get(spec, 'frozen', 0)
+    let spec.submod = get(spec, 'submod', 0)
   endfor
 endfunction
 


### PR DESCRIPTION
Add an option "submod" that's allows disabling cloning of sub-modules. Default behavior is the same as before.

I have run into two use cases.
1. Some plugins (e.g YCM) have many sub-modules required only for optional functionality. It would be nice to not have to download these on updates.
2. Some projects (e.g Omnisharp-vim) reference old versions of the sub-modules. This option would allow the user to still use vim-plug's update functionality and manually handle issues with sub-module references. 