### PR TITLE
Add environment variable for use with 'do':

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -126,6 +126,8 @@ function! plug#begin(...)
   let g:plugs_order = []
   let s:triggers = {}
 
+  let $VIMPLUG_DIR = home
+
   call s:define_commands()
   return 1
 endfunction


### PR DESCRIPTION
I've found it handy to be able to reference the path set in plug#begin from the 'do' command. So I've introduced the environment variable $VIMPLUG_DIR.
