### PR TITLE
Set nolist in vim-plug buffers

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -749,7 +749,7 @@ function! s:prepare(...)
   for k in ['<cr>', 'L', 'o', 'X', 'd', 'dd']
     execute 'silent! unmap <buffer>' k
   endfor
-  setlocal buftype=nofile bufhidden=wipe nobuflisted noswapfile nowrap cursorline modifiable
+  setlocal buftype=nofile bufhidden=wipe nobuflisted nolist noswapfile nowrap cursorline modifiable
   setf vim-plug
   if exists('g:syntax_on')
     call s:syntax()


### PR DESCRIPTION
In the buffer opened by `:PlugInstall`, lines streaming the output from `git clone` have trailing whitespace, which is highlighted by default in Neovim when `list` is enabled. By disabling `list` in the buffer, this whitespace is no longer highlighted.