### PR TITLE
git_validate: better error with checkout being ahead/diverged

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -2018,18 +2018,15 @@ function! s:git_validate(spec, check_branch)
               \ a:spec.branch), a:spec.dir)), '\t')
         if !v:shell_error && ahead
           if behind
-            let base_error = printf(
-                  \ 'Diverged from origin/%%s (%%d commit(s) ahead and %d commit(s) behind!', behind)
+            " Only mention PlugClean if diverged, otherwise it's likely to be
+            " pushable (and probably not that messed up).
+            let err = printf(
+                  \ "Diverged from origin/%s (%d commit(s) ahead and %d commit(s) behind!\n"
+                  \ .'Backup local changes and run PlugClean and PlugUpdate to reinstall it.', a:spec.branch, ahead, behind)
           else
-            let base_error = 'Ahead of origin/%s by %d commit(s).'
-          endif
-          let err = join([printf(base_error, a:spec.branch, ahead),
-                \ 'Can you push it yourself?',
-                \ 'Otherwise try reinstalling it after cleaning it manually.'], "\n")
-          " Only mention PlugClean if diverged, otherwise it's likely to be
-          " pushable (and probably not that messed up).
-          if behind
-            let err .= "\nTry PlugClean after backing it up."
+            let err = printf("Ahead of origin/%s by %d commit(s).\n"
+                  \ .'Cannot update until local changes are pushed.',
+                  \ a:spec.branch, ahead)
           endif
         endif
       endif

--- a/test/workflow.vader
+++ b/test/workflow.vader
@@ -212,7 +212,7 @@ Expect:
   [==]
   x seoul256.vim:
 
-Execute (Corrected the URI but diverged from master):
+Execute (Corrected the URI but ahead of upstream):
   call plug#begin()
   Plug 'junegunn/seoul256.vim'
   Plug 'file:///tmp/vim-plug-test/jg/vim-emoji'
@@ -223,8 +223,8 @@ Execute (Corrected the URI but diverged from master):
   call PlugStatusSorted()
 
 Expect:
-      Diverged from origin/master by 3 commit(s).
-      Reinstall after PlugClean.
+      Ahead of origin/master by 3 commit(s).
+      Cannot update until local changes are pushed.
   - vim-emoji: OK
   Finished. 1 error(s).
   [==]
@@ -237,11 +237,44 @@ Expect:
 #   q
 #   PGdd
 
-Execute (PlugClean! to remove seoul256.vim):
+Execute (PlugClean! keeps seoul256.vim):
   PlugClean!
-  " Three removed, emoji left
-  AssertEqual 'Removed 3 directories.', getline(4)
-  AssertExpect '^\~ ', 3
+  " Two removed, emoji and seoul256 left
+  AssertEqual 'Removed 2 directories.', getline(4)
+  AssertExpect '^\~ ', 2
+  AssertExpect 'Diverged', 0
+  Assert !empty(globpath(&rtp, 'colors/seoul256.vim'))
+  Assert !empty(globpath(&rtp, 'autoload/emoji.vim'))
+  q
+
+Execute (Make seoul256 to be diverged):
+  call plug#begin()
+  Plug 'junegunn/seoul256.vim'
+  Plug 'file:///tmp/vim-plug-test/jg/vim-emoji'
+  call plug#end()
+  call system(printf(join([
+    \ 'cd "%s"',
+    \ 'git fetch --unshallow',
+    \ 'git reset "@{u}~1"',
+    \ 'git commit --allow-empty -m "diverged1"',
+    \ 'git commit --allow-empty -m "diverged2"'], ' && '),
+    \ g:plugs['seoul256.vim'].dir))
+  Assert empty(v:shell_error), 'Got shell error: '.v:shell_error
+  call PlugStatusSorted()
+
+Expect:
+      Backup local changes and run PlugClean and PlugUpdate to reinstall it.
+      Diverged from origin/master (2 commit(s) ahead and 1 commit(s) behind!
+  - vim-emoji: OK
+  Finished. 1 error(s).
+  [==]
+  x seoul256.vim:
+
+Execute (PlugClean! removes seoul256.vim):
+  PlugClean!
+  " One removed, emoji left
+  AssertEqual 'Removed 1 directories.', getline(4)
+  AssertExpect '^\~ ', 1
   AssertExpect 'Diverged', 1
   Assert empty(globpath(&rtp, 'colors/seoul256.vim'))
   Assert !empty(globpath(&rtp, 'autoload/emoji.vim'))


### PR DESCRIPTION
The `--count` and `--left-right` options seem to be in Git since before
1.7 already.

The error message is improved, and distinguishes between only being
ahead (which is the case if you could push), or being diverged (ahead
and defined).

I think it could be bad to accidentally clean/delete a local checkout
which is ahead, and therefore PlugClean is not mentioned then, which
appears to trigger it to show up in :PlugClean.

btw: what about using `@{upstream}` (Git 1.7.0) more / in general?
