### PR TITLE
Deferred loading on autocmd (#event[#pattern])

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,16 +121,16 @@ Reload .vimrc and `:PlugInstall` to install plugins.
 
 ### `Plug` options
 
-| Option                  | Description                                      |
-| ----------------------- | ------------------------------------------------ |
-| `branch`/`tag`/`commit` | Branch/tag/commit of the repository to use       |
-| `rtp`                   | Subdirectory that contains Vim plugin            |
-| `dir`                   | Custom directory for the plugin                  |
-| `as`                    | Use different name for the plugin                |
-| `do`                    | Post-update hook (string or funcref)             |
-| `on`                    | On-demand loading: Commands or `<Plug>`-mappings |
-| `for`                   | On-demand loading: File types                    |
-| `frozen`                | Do not update unless explicitly specified        |
+| Option                  | Description                                                  |
+| ----------------------- | -----------------------------------------------------------  |
+| `branch`/`tag`/`commit` | Branch/tag/commit of the repository to use                   |
+| `rtp`                   | Subdirectory that contains Vim plugin                        |
+| `dir`                   | Custom directory for the plugin                              |
+| `as`                    | Use different name for the plugin                            |
+| `do`                    | Post-update hook (string or funcref)                         |
+| `on`                    | On-demand loading: Commands, `<Plug>`-mappings, or #autocmds |
+| `for`                   | On-demand loading: File types                                |
+| `frozen`                | Do not update unless explicitly specified                    |
 
 ### Global options
 
@@ -179,6 +179,9 @@ Plug 'tpope/vim-fireplace', { 'for': 'clojure' }
 
 " Multiple file types
 Plug 'kovisoft/paredit', { 'for': ['clojure', 'scheme'] }
+
+" On autocmd
+Plug 'SirVer/ultisnips', { 'on': '#InsertEnter' }
 
 " On-demand loading on both conditions
 Plug 'junegunn/vader.vim',  { 'on': 'Vader', 'for': 'vader' }

--- a/plug.vim
+++ b/plug.vim
@@ -229,9 +229,16 @@ function! plug#end()
             call s:assoc(lod.cmd, cmd, name)
           endif
           call add(s:triggers[name].cmd, cmd)
+        elseif cmd[0] == '#' && exists('##'.split(cmd, '#')[0])
+          let tokens = split(cmd, '#')
+          let group = 'Plug/'.name
+          execute 'augroup' group
+          autocmd!
+          execute 'autocmd' tokens[0] get(tokens, 1, '*') printf('call s:lod_autocmd(%s)', string(name))
+          execute 'augroup END'
         else
           call s:err('Invalid `on` option: '.cmd.
-          \ '. Should start with an uppercase letter or `<Plug>`.')
+          \ '. Should start with an uppercase letter, `<Plug>`, or `#`.')
         endif
       endfor
     endif
@@ -443,9 +450,7 @@ function! plug#load(...)
     let s = len(unknowns) > 1 ? 's' : ''
     return s:err(printf('Unknown plugin%s: %s', s, join(unknowns, ', ')))
   end
-  for name in a:000
-    call s:lod([name], ['ftdetect', 'after/ftdetect', 'plugin', 'after/plugin'])
-  endfor
+  call s:lod(a:000, ['ftdetect', 'after/ftdetect', 'plugin', 'after/plugin'])
   call s:dobufread(a:000)
   return 1
 endfunction
@@ -524,6 +529,14 @@ function! s:lod_map(map, names, with_prefix, prefix)
     call feedkeys(prefix, 'n')
   endif
   call feedkeys(substitute(a:map, '^<Plug>', "\<Plug>", '') . extra)
+endfunction
+
+function! s:lod_autocmd(name)
+  call s:lod([a:name], ['ftdetect', 'after/ftdetect', 'plugin', 'after/plugin'])
+  call s:dobufread([a:name])
+  let group = 'Plug/'.a:name
+  execute 'autocmd!' group
+  execute 'augroup!' group
 endfunction
 
 function! plug#(repo, ...)


### PR DESCRIPTION
Does not mean that I'm positive on this. I'm just posting the patch as it was trivial to implement the idea.

```vim
Plug 'SirVer/ultisnips',  { 'on': '#InsertEnter' }
Plug 'junegunn/goyo.vim', { 'on': ['Goyo', '#BufEnter#README,BUILD,CHANGELOG'] }
```

(See `:help exists()` for `#event#pattern` syntax)