### PR TITLE
Fix git version detection.

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -312,7 +312,7 @@ endfunction
 
 function! s:git_version_requirement(...)
   if !exists('s:git_version')
-    let s:git_version = map(split(split(s:system('git --version'))[-1], '\.'), 'str2nr(v:val)')
+    let s:git_version = map(split(split(s:system('git --version'))[2], '\.'), 'str2nr(v:val)')
   endif
   return s:version_requirement(s:git_version, a:000)
 endfunction


### PR DESCRIPTION
### Bug report
vim-plug detects the version of git by taking the output of `git --version`, and extracting the last group of characters separated by spaces. But it fails to extract the version number from the output correctly in with Apple's version of git in macOS. This happens because Apple adds their own release number at the end of `git --version`.  So where `git --version` on say, Ubuntu shows:
```console
$ git --version
git version 2.7.4
```
`git --version` on macOS shows:
```console
$ git --version
git version 2.9.3 (Apple Git-75)
```
Here, vim-plug can't detect the version correctly for Apple's git, since it's looking at the `Git-75)` part, not `2.9.3`.

This is especially problematic for macOS, because failure to correctly detect the version of git causes vim-plug to [inject](https://github.com/junegunn/vim-plug/wiki/faq#whats-the-deal-with-git-in-the-url) `git::@` in the URL by default. When this URL is used to download plugins, an invalid entry is made in the Keychain, causing problems for other programs accessing GitHub (See screenshots below).
![Keychain1](https://cloud.githubusercontent.com/assets/7343721/19969979/e47db7c0-a21d-11e6-8c1e-76bc0d5d097b.png)
![Keychain2](https://cloud.githubusercontent.com/assets/7343721/19969986/e94a7f68-a21d-11e6-9292-2570973ea268.png)
![Homebrew](https://cloud.githubusercontent.com/assets/7343721/19969995/f082d870-a21d-11e6-9069-ef8acfd6905c.png)

### Changes in this PR
The second group of characters separated by spaces is extracted from `git --version`, instead of the last.