### PR TITLE
Do not check spelling in vim-plug buffers

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -751,7 +751,7 @@ function! s:prepare(...)
   for k in ['<cr>', 'L', 'o', 'X', 'd', 'dd']
     execute 'silent! unmap <buffer>' k
   endfor
-  setlocal buftype=nofile bufhidden=wipe nobuflisted nolist noswapfile nowrap cursorline modifiable
+  setlocal buftype=nofile bufhidden=wipe nobuflisted nolist noswapfile nowrap cursorline modifiable nospell
   setf vim-plug
   if exists('g:syntax_on')
     call s:syntax()


### PR DESCRIPTION
I added `nospell` to the settings of the `vim-plug` buffer. Since the user never types anything into this buffer and plugins can have weird names along with professional jargone there is no point in spell-checking anything.