### PR TITLE
Introduce new command PlugOpen to browse the directory of a plugin.

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -138,6 +138,7 @@ function! s:define_commands()
   endif
   command! -nargs=* -bar -bang -complete=customlist,s:names PlugInstall call s:install(<bang>0, [<f-args>])
   command! -nargs=* -bar -bang -complete=customlist,s:names PlugUpdate  call s:update(<bang>0, [<f-args>])
+  command! -nargs=* -bar -bang -complete=customlist,s:names PlugOpen    call s:open(<bang>'',<f-args>)
   command! -nargs=0 -bar -bang PlugClean call s:clean(<bang>0)
   command! -nargs=0 -bar PlugUpgrade if s:upgrade() | execute 'source' s:esc(s:me) | endif
   command! -nargs=0 -bar PlugStatus  call s:status()
@@ -590,6 +591,10 @@ endfunction
 
 function! s:update(force, names)
   call s:update_impl(1, a:force, a:names)
+endfunction
+
+function! s:open(force, name)
+  exec ':Sexplore'.a:force.' '.g:plug_home.'/'.a:name.'/'
 endfunction
 
 function! plug#helptags()

--- a/plug.vim
+++ b/plug.vim
@@ -594,7 +594,12 @@ function! s:update(force, names)
 endfunction
 
 function! s:open(force, name)
-  exec ':Sexplore'.a:force.' '.g:plug_home.'/'.a:name.'/'
+  let plugpath = g:plug_home.'/'.a:name.'/'
+  if a:force
+    exec ':Sexplore! '. plugpath
+  else
+    exec ':Sexplore '. plugpath
+  endif
 endfunction
 
 function! plug#helptags()


### PR DESCRIPTION
One of the great features of Bundler (a package manager in Ruby) is the `bundle open` command which allows me to quickly view the source of a gem.

The behaviour is quite neat after executing `bundle open` vim opens in NetRw explore mode with the gem directory is `cd`.

I wished to have similar functionality in vim where I could invoke `PlugOpen Fzf.vim` for example to open a netrw split that browses the plug directory of that plugin.

This PR does just that, it adds a new command `PlugOpen` which has autocomplete for all installed and managed Plugs, the user can supply a bang (!) to change the split behaviour from horizontal to vertical.

If you want I can add a screenrecording showing the command in action.
