### PR TITLE
Fix crlf in clones under cygwin (#497)

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -986,6 +986,10 @@ function! s:update_impl(pull, force, args) abort
   let s:clone_opt = get(g:, 'plug_shallow', 1) ?
         \ '--depth 1' . (s:git_version_requirement(1, 7, 10) ? ' --no-single-branch' : '') : ''
 
+  if has('win32unix')
+    let s:clone_opt .= ' -c core.eol=lf -c core.autocrlf=input'
+  endif
+
   " Python version requirement (>= 2.7)
   if python && !has('python3') && !ruby && !use_job && s:update.threads > 1
     redir => pyv


### PR DESCRIPTION
This pull request is actually very similar to #497, but since it seems to have been abandoned, here you go.

I have tested under cygwin, and it works :)

In a nutshell:

1. Under Windows and Linux, there's no problem; `core.autocrlf` takes care of everything.
2. Under Cygwin, the Windows version of vim will *not* work and it will complain about `^M` everywhere.
3. I cannot configure `git` globally under cygwin, because I *want* my Windows files to be `crlf`, even though I am working in Cygwin

The solution is to have the vim plugins clone with `lf` under cygwin.

I can now SSH on my windows machine and work :)