### PR TITLE
PlugStatus showed error with wildcard tag

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -2022,7 +2022,7 @@ function! s:git_validate(spec, check_branch)
       " Check tag
       if has_key(a:spec, 'tag')
         let tag = s:system_chomp('git describe --exact-match --tags HEAD 2>&1', a:spec.dir)
-        if a:spec.tag !=# tag
+        if a:spec.tag !=# tag && a:spec.tag !~ '\*'
           let err = printf('Invalid tag: %s (expected: %s). Try PlugUpdate.',
                 \ (empty(tag) ? 'N/A' : tag), a:spec.tag)
         endif

--- a/test/regressions.vader
+++ b/test/regressions.vader
@@ -354,3 +354,16 @@ Expect:
   - new-branch: OK
   Finished. 0 error(s).
   [=]
+
+**********************************************************************
+Execute (PlugStatus showed error with wildcard tag):
+  call plug#begin()
+  Plug 'junegunn/vim-easy-align', { 'tag': '*' }
+  call plug#end()
+  PlugUpdate
+  call PlugStatusSorted()
+
+Expect:
+  - vim-easy-align: OK
+  Finished. 0 error(s).
+  [=]


### PR DESCRIPTION
:PlugStatus was reporting an invalid tag when using e.g.`Plug 'fatih/vim-go', { 'tag': '*' }`


![plugstatus](https://cloud.githubusercontent.com/assets/10963046/25014940/b2f81ff6-2071-11e7-860a-035a0ef29f3d.png)

