### PR TITLE
Add .config path for installation "script"

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ curl -fLo ~/.local/share/nvim/site/autoload/plug.vim --create-dirs \
     https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 ```
 
+**OR** _(if previous didn't work)_
+
+```sh
+curl -fLo ~/.config/nvim/autoload/plug.vim --create-dirs \
+    https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+```
+_Last one is better for later versions of neovim_
+
 ###### Windows (PowerShell)
 
 ```powershell


### PR DESCRIPTION
This is done becase latest versions of NeoVIM use this path as path where configurations
and plugins are places