### PR TITLE
Prefer Python over Vim 8 jobs in Windows

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -970,7 +970,7 @@ function! s:update_impl(pull, force, args) abort
   endif
 
   let use_job = s:nvim || s:vim8
-  let python = (has('python') || has('python3')) && !use_job
+  let python = (has('python') || has('python3')) && (s:is_win || !use_job)
   let ruby = has('ruby') && !use_job && (v:version >= 703 || v:version == 702 && has('patch374')) && !(s:is_win && has('gui_running')) && threads > 1 && s:check_ruby()
 
   let s:update = {


### PR DESCRIPTION
Workaround on Vim 8 jobs spawning multiple, minimized cmd.exe terminals in GVim.
Without python, generating a batchfile with all of the shell commands for each `Plug` and running it under one cmd.exe terminal is the only solution I can think of.