### PR TITLE
Fix Travis CI build (dist: trusty)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+dist: trusty
 sudo: false
 env:
   global:
@@ -53,6 +54,7 @@ install: |
 
   git clone --depth 1 https://github.com/vim/vim
   cd vim
+  export PATH=/usr/bin:$PATH
   ./configure $C_OPTS
   make
   make install


### PR DESCRIPTION
1. Fix Neovim bulid by using Trusty environment
2. Make sure Vim does not link to wrong Python (`/opt/python/3.5.3`)