### PR TITLE
Prepend 'silent' to ':!' to avoid hit-enter prompt in GVim on Windows

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -802,7 +802,7 @@ function! s:bang(cmd, ...)
       call writefile(['@echo off', cmd], batchfile)
       let cmd = batchfile
     endif
-    let g:_plug_bang = '!'.escape(cmd, '#!%')
+    let g:_plug_bang = (s:is_win && has('gui_running') ? 'silent ' : '').'!'.escape(cmd, '#!%')
     execute "normal! :execute g:_plug_bang\<cr>\<cr>"
   finally
     unlet g:_plug_bang


### PR DESCRIPTION
Close #606