### PR TITLE
Use s:path with s:rtp always

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -334,11 +334,11 @@ function! s:progress_opt(base)
         \ s:git_version_requirement(1, 7, 1) ? '--progress' : ''
 endfunction
 
-if s:is_win
-  function! s:rtp(spec)
-    return s:path(a:spec.dir . get(a:spec, 'rtp', ''))
-  endfunction
+function! s:rtp(spec)
+  return s:path(a:spec.dir . get(a:spec, 'rtp', ''))
+endfunction
 
+if s:is_win
   function! s:path(path)
     return s:trim(substitute(a:path, '/', '\', 'g'))
   endfunction
@@ -374,10 +374,6 @@ if s:is_win
     return [batchfile, cmd]
   endfunction
 else
-  function! s:rtp(spec)
-    return s:dirpath(a:spec.dir . get(a:spec, 'rtp', ''))
-  endfunction
-
   function! s:path(path)
     return s:trim(a:path)
   endfunction


### PR DESCRIPTION
Having a trailing slash with &rtp entries is problematic when removing
them later: if loading on demand is used, s:reorg_rtp might fail to
remove the previous runtime paths.

Test case has been using maktaba (which triggers unsetting s:middle in
s:reorg_rtp), but because of the trailing slashes being used, the
previous rtp entries were not removed.