### PR TITLE
Add another install way

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,20 @@ and put it in the "autoload" directory.
 
 ###### Unix
 
+- Terminal way:
+
 ```sh
 curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
     https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+```
+
+- Vimrc way:
+
+```vim
+" Put these lines into your vimrc. vim-plug will be installed automatically.
+if !filereadable(glob('~/.vim/autoload/plug.vim'))
+    call system("curl -fLo ~/.vim/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim")
+endif
 ```
 
 ###### Windows (PowerShell)
@@ -53,9 +64,20 @@ $uri = 'https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
 
 ###### Unix
 
+- Terminal way:
+
 ```sh
 curl -fLo ~/.local/share/nvim/site/autoload/plug.vim --create-dirs \
     https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+```
+
+- Vimrc way:
+
+```vim
+" Put these lines into your vimrc. vim-plug will be installed automatically. 
+if !filereadable(glob('~/.local/share/nvim/site/autoload/plug.vim'))
+    call system("curl -fLo ~/.local/share/nvim/site/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim")
+endif
 ```
 
 ###### Windows (PowerShell)


### PR DESCRIPTION
Add another install way which vim will download and install the `vim-plug` automatically. Nothing will happen if it was already installed.
The benefit of this approach is that we don't need to run the install command manually. When restoring configurations on a new machine, only thing to do is copy the `vimrc` file or make a symbol link. :smiley: 

<!-- ## Before Submitting

- You made sure the existing tests/travis build works.
- You made sure any new features were tested where appropriate.
- You checked a similar feature wasn't already turned down by searching issues & PRs.
-->
