### PR TITLE
Corrects neovim installation directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $uri = 'https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
 ###### Unix
 
 ```sh
-curl -fLo ~/.local/share/nvim/site/autoload/plug.vim --create-dirs \
+curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
     https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 ```
 


### PR DESCRIPTION
This is to match the more correct location for the `autoload` directory, so that it matches the [instructions on the Wiki](https://travis-ci.org/nulogy/Gorgon/builds).
