### PR TITLE
Add a note to the installation section about following the usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ A minimalist Vim plugin manager.
 [Download plug.vim](https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim)
 and put it in the "autoload" directory.
 
+**Warning** Don't forget to follow the instructions in the Usage section as well!
+
 #### Vim
 
 ###### Unix


### PR DESCRIPTION
I spent an inordinate amount of time trying to figure out why after installation I could not simply follow a simple installation instruction like

```
    Add Plug 'iCyMind/NeoSolarized' to your init.vim or .vimrc file.
    Run :PlugInstall after resourcing/relaunching.
```

And then I saw the "Usage" section. But initially I skipped over that since I was done installing vim-plug. (also I think "Configuration" would make more sense than "Usage").