### PR TITLE
Make directions a little more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Add a vim-plug section to your `~/.vimrc` (or `~/.config/nvim/init.vim` for Neov
     - Automatically executes `filetype plugin indent on` and `syntax enable`.
       You can revert the settings after the call. e.g. `filetype indent off`, `syntax off`, etc.
 
-#### Example
+#### Example .vimrc file
 
 ```vim
 " Specify a directory for plugins


### PR DESCRIPTION
I had a bit of trouble figuring out where to put this stuff before I figured out it was supposed to live in my `.vimrc` file. Maybe this will save some time for the next developer.
