### PR TITLE
Add <plug>(plug-preview) map

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -2426,8 +2426,13 @@ function! s:diff()
         \ . (cnts[1] ? printf(' %d plugin(s) have pending updates.', cnts[1]) : ''))
 
   if cnts[0] || cnts[1]
-    nnoremap <silent> <buffer> <cr> :silent! call <SID>preview_commit()<cr>
-    nnoremap <silent> <buffer> o    :silent! call <SID>preview_commit()<cr>
+    nnoremap <silent> <buffer> <plug>(plug-preview) :silent! call <SID>preview_commit()<cr>
+    if empty(maparg("\<cr>", 'n'))
+      nmap <buffer> <cr> <plug>(plug-preview)
+    endif
+    if empty(maparg('o', 'n'))
+      nmap <buffer> o <plug>(plug-preview)
+    endif
   endif
   if cnts[0]
     nnoremap <silent> <buffer> X :call <SID>revert()<cr>

--- a/test/workflow.vader
+++ b/test/workflow.vader
@@ -370,8 +370,15 @@ Execute (New commits on remote, PlugUpdate, then PlugDiff):
   AssertEqual 1, &previewwindow
   AssertEqual 'git', &filetype
 
-  " Back to plug window
-  wincmd p
+  " Close preview window
+  pclose
+
+  " Open and go to preview window with a custom mapping
+  nmap <buffer> <c-o> <plug>(plug-preview)<c-w>P
+  execute "normal \<c-o>"
+  AssertEqual 1, &previewwindow, 'Should be on preview window'
+  normal q
+  AssertEqual 0, &previewwindow, 'Should not be on preview window'
 
   " ]] motion
   execute 'normal $]]'


### PR DESCRIPTION
This allows you to override the default behavior of `o` or `<cr>` binding in PlugDiff window.

```vim
" Move to preview window
autocmd! FileType vim-plug nmap <buffer> o <plug>(plug-preview)<c-w>P
````

Close #749
Close #768
