### PR TITLE
Unset colorcolumn in vim-plug buffer

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -763,6 +763,9 @@ function! s:prepare(...)
     execute 'silent! unmap <buffer>' k
   endfor
   setlocal buftype=nofile bufhidden=wipe nobuflisted nolist noswapfile nowrap cursorline modifiable nospell
+  if exists('+colorcolumn')
+    setlocal colorcolumn=
+  endif
   setf vim-plug
   if exists('g:syntax_on')
     call s:syntax()


### PR DESCRIPTION
Colorcolumn is an option people use to make it easier for them to see if a line has the traditional 80 character limit. Since vim-plug does not respect that limit, this pull request disables the colorcolumn option.