### PR TITLE
Allow cloning into an empty directory

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -1321,7 +1321,7 @@ while 1 " Without TCO, Vim stack is bound to explode
 
   let name = keys(s:update.todo)[0]
   let spec = remove(s:update.todo, name)
-  let new  = !isdirectory(spec.dir)
+  let new  = empty(globpath(spec.dir, '.git', 1))
 
   call s:log(new ? '+' : '*', name, pull ? 'Updating ...' : 'Installing ...')
   redraw

--- a/test/workflow.vader
+++ b/test/workflow.vader
@@ -1641,6 +1641,7 @@ Execute (#532 - Reuse plug window):
 
 Execute (#766 - Allow cloning into an empty directory):
   let d = '/tmp/vim-plug-test/goyo-already'
+  call system('rm -rf ' . d)
   call mkdir(d)
   call plug#begin()
   Plug 'junegunn/goyo.vim', { 'dir': d }

--- a/test/workflow.vader
+++ b/test/workflow.vader
@@ -1511,7 +1511,7 @@ Execute (Commit hash support):
   Log getline(1, '$')
   AssertEqual 'x goyo.vim:', getline(5)
   AssertEqual '    fatal: invalid reference: ffffffff', getline(6)
-  AssertEqual 0, stridx(getline(7), '- vim-emoji: HEAD is now at 9db7fcf...')
+  AssertEqual 0, stridx(getline(7), '- vim-emoji: HEAD is now at 9db7fcf')
 
   let hash = system(printf('cd %s && git rev-parse HEAD', g:plugs['vim-emoji'].dir))[:-2]
   AssertEqual '9db7fcfee0d90dafdbcb7a32090c0a9085eb054a', hash
@@ -1638,3 +1638,14 @@ Execute (#532 - Reuse plug window):
   AssertEqual 2, winnr(), 'Current window is #2 after PlugStatus (but is '.winnr().')'
   AssertEqual 2, winnr('$'), 'Three windows after PlugStatus (but got '.winnr('$').')'
   q
+
+Execute (#766 - Allow cloning into an empty directory):
+  let d = '/tmp/vim-plug-test/goyo-already'
+  call mkdir(d)
+  call plug#begin()
+  Plug 'junegunn/goyo.vim', { 'dir': d }
+  call plug#end()
+  PlugInstall
+  AssertExpect! '[=]', 1
+  q
+  unlet d


### PR DESCRIPTION
Close #766

This can be useful if you want to install plugins to directories outside user home directory.