### PR TITLE
Ignore useless use of on-demand loading

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -195,7 +195,7 @@ endfunction
 
 function! s:has_for(plug)
   return has_key(a:plug, 'for') &&
-        \ (empty(s:to_a(a:plug.for)) || len(s:glob(s:rtp(a:plug), 'plugin')))
+        \ (empty(s:to_a(a:plug.for)) || !isdirectory(a:plug.dir) || len(s:glob(s:rtp(a:plug), 'plugin')))
 endfunction
 
 function! plug#end()

--- a/plug.vim
+++ b/plug.vim
@@ -193,6 +193,11 @@ function! s:ask_no_interrupt(...)
   endtry
 endfunction
 
+function! s:has_for(plug)
+  return has_key(a:plug, 'for') &&
+        \ (empty(s:to_a(a:plug.for)) || len(s:glob(s:rtp(a:plug), 'plugin')))
+endfunction
+
 function! plug#end()
   if !exists('g:plugs')
     return s:err('Call plug#begin() first')
@@ -214,7 +219,7 @@ function! plug#end()
       continue
     endif
     let plug = g:plugs[name]
-    if get(s:loaded, name, 0) || !has_key(plug, 'on') && !has_key(plug, 'for')
+    if get(s:loaded, name, 0) || !has_key(plug, 'on') && !s:has_for(plug)
       let s:loaded[name] = 1
       continue
     endif

--- a/plug.vim
+++ b/plug.vim
@@ -193,9 +193,12 @@ function! s:ask_no_interrupt(...)
   endtry
 endfunction
 
-function! s:has_for(plug)
-  return has_key(a:plug, 'for') &&
-        \ (empty(s:to_a(a:plug.for)) || !isdirectory(a:plug.dir) || len(s:glob(s:rtp(a:plug), 'plugin')))
+function! s:lazy(plug, opt)
+  return has_key(a:plug, a:opt) &&
+        \ (empty(s:to_a(a:plug[a:opt]))         ||
+        \  !isdirectory(a:plug.dir)             ||
+        \  len(s:glob(s:rtp(a:plug), 'plugin')) ||
+        \  len(s:glob(s:rtp(a:plug), 'after/plugin')))
 endfunction
 
 function! plug#end()
@@ -219,7 +222,7 @@ function! plug#end()
       continue
     endif
     let plug = g:plugs[name]
-    if get(s:loaded, name, 0) || !has_key(plug, 'on') && !s:has_for(plug)
+    if get(s:loaded, name, 0) || !s:lazy(plug, 'on') && !s:lazy(plug, 'for')
       let s:loaded[name] = 1
       continue
     endif

--- a/test/regressions.vader
+++ b/test/regressions.vader
@@ -41,6 +41,7 @@ Execute (#130 Proper cleanup of on-demand loading triggers):
   Plug 'junegunn/vim-emoji', { 'on':  ['EmojiCommand', 'EmojiCommand2', '<Plug>(EmojiMapping)'] }
   call plug#end()
   PlugInstall | q
+  call mkdir(g:plugs['vim-emoji'].dir.'/after/plugin', 'p')
 
   Assert exists(':EmojiCommand'), 'EmojiCommand not defined'
   Assert exists(':EmojiCommand2'), 'EmojiCommand2 not defined'

--- a/test/run
+++ b/test/run
@@ -87,7 +87,7 @@ DOC
   make_dirs z2/ z2
 
   rm -rf "$PLUG_FIXTURES/ftplugin-msg"
-  mkdir -p "$PLUG_FIXTURES/ftplugin-msg/ftplugin"
+  mkdir -p "$PLUG_FIXTURES"/ftplugin-msg/{plugin,ftplugin}
   echo "echomsg 'ftplugin-c'" > "$PLUG_FIXTURES/ftplugin-msg/ftplugin/c.vim"
   echo "echomsg 'ftplugin-java'" > "$PLUG_FIXTURES/ftplugin-msg/ftplugin/java.vim"
 


### PR DESCRIPTION
`for` option is useless for plugins without `plugin` directory.

Close #785 