### PR TITLE
Implement ability to override git clone options for a particular plugin

### DIFF
--- a/doc/plug.txt
+++ b/doc/plug.txt
@@ -216,6 +216,7 @@ Reload .vimrc and `:PlugInstall` to install plugins.
   `on`                     | On-demand loading: Commands or <Plug>-mappings
   `for`                    | On-demand loading: File types
   `frozen`                 | Do not update unless explicitly specified
+  `clone_opt`              | Override git cloning options for the plugin
  ------------------------+-----------------------------------------------
 
 

--- a/plug.vim
+++ b/plug.vim
@@ -1337,6 +1337,8 @@ while 1 " Without TCO, Vim stack is bound to explode
   redraw
 
   let has_tag = has_key(spec, 'tag')
+  let has_clone_opt = has_key(spec, 'clone_opt')
+  let clone_opt = has_clone_opt ? spec.clone_opt : s:clone_opt
   if !new
     let [error, _] = s:git_validate(spec, 0)
     if empty(error)
@@ -1352,7 +1354,7 @@ while 1 " Without TCO, Vim stack is bound to explode
   else
     call s:spawn(name,
           \ printf('git clone %s %s %s %s 2>&1',
-          \ has_tag ? '' : s:clone_opt,
+          \ has_tag ? '' : clone_opt,
           \ prog,
           \ s:shellesc(spec.uri),
           \ s:shellesc(s:trim(spec.dir))), { 'new': 1 })


### PR DESCRIPTION
This PR is intended to allow users to manually override how git clones a particular repository. An example use case would be when trying to install the `LanguageClient-neovim` plugin. If that plugin is installed like this:

```
Plug 'autozimu/LanguageClient-neovim', {
    \ 'branch': 'next',
    \ 'do': 'bash install.sh',
    \ }
```

It will download ~97MB, even when `g:plug_shallow` is set to 1. The reason is that `plug.vim` still specifies `--no-single-branch` on git versions more than 1.7.10 as can be seen from these lines in `plug.vim`:

```
let s:clone_opt = get(g:, 'plug_shallow', 1) ?
        \ '--depth 1' . (s:git_version_requirement(1, 7, 10) ? ' --no-single-branch' : '') : ''
```

So while we're only interested in the `next` branch specified in the configuration above, it downloads the entire .git history, including some very large binary files that are left over from older commits. This PR makes it possible to do the following:

```
Plug 'autozimu/LanguageClient-neovim', {
    \ 'branch': 'next',
    \ 'do': 'bash install.sh',
    \ 'clone_opt': '--depth 1'
    \ }
```

Which omits the `--no-single-branch` option. In turn that dramatically reduces the size of the repo down to 300KB.

There are some potential issues I can think of with this PR, for example, allowing users to specify arbitrary git clone options may break other VimPlug functionality. For example, without `--no-single-branch`, changing the branch and doing `PlugUpdate` no longer works correctly. This might be an acceptable tradeoff for some users (it is for me), but might not be for the general use case.

Please let me know what you think. If there is anything I can do to improve this PR I'd be happy to do that.