### PR TITLE
Help people find "Uninstall Docs"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ A minimalist Vim plugin manager.
 
 - Easier to setup: Single file. No boilerplate code required.
 - Easier to use: Concise, intuitive syntax
-- [Super-fast][40/4] parallel installation/update
+- [Super-fast][40/4] parallel installation/
+update
   (with any of `+job`, `+python`, `+python3`, `+ruby`, or [Neovim][nv])
 - Creates shallow clones to minimize disk space usage and download time
 - On-demand loading for [faster startup time][startup-time]
@@ -148,7 +149,7 @@ Reload .vimrc and `:PlugInstall` to install plugins.
 | ----------------------------------- | ------------------------------------------------------------------ |
 | `PlugInstall [name ...] [#threads]` | Install plugins                                                    |
 | `PlugUpdate [name ...] [#threads]`  | Install or update plugins                                          |
-| `PlugClean[!]`                      | Remove unused directories (bang version will clean without prompt) |
+| `PlugClean[!]`                      | Remove (Uninstall) unused plugin directories (bang version will clean without prompt) |
 | `PlugUpgrade`                       | Upgrade vim-plug itself                                            |
 | `PlugStatus`                        | Check the status of plugins                                        |
 | `PlugDiff`                          | Examine changes from the previous update and the pending changes   |


### PR DESCRIPTION
Helps address #121.  Before, if you searched the readme for "uninstall", there were no results. Which is odd, because "Uninstall" seems like a natural opposite to "Install".

Also, "Removing directories" did not clearly communicate that the directories being removed were *plugin* directories.

As #121 showed, clearly a lot of people were challenged to figure out how to uninstall based on the current docs.

<!-- ## Before Submitting

- You made sure the existing tests/travis build works.
- You made sure any new features were tested where appropriate.
- You checked a similar feature wasn't already turned down by searching issues & PRs.
-->

Describe the details of your PR ...
