### PR TITLE
feat(diff): use 'rtp' option to filter diff

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -2420,7 +2420,11 @@ function! s:diff()
     call s:append_ul(2, origin ? 'Pending updates:' : 'Last update:')
     for [k, v] in plugs
       let range = origin ? '..origin/'.v.branch : 'HEAD@{1}..'
-      let diff = s:system_chomp('git log --graph --color=never '.join(map(['--pretty=format:%x01%h%x01%d%x01%s%x01%cr', range], 's:shellesc(v:val)')).' -- .', s:rtp(v))
+      let cmd = 'git log --graph --color=never '.join(map(['--pretty=format:%x01%h%x01%d%x01%s%x01%cr', range], 's:shellesc(v:val)'))
+      if has_key(v, 'rtp')
+        let cmd .= ' -- ' . v.rtp
+      endif
+      let diff = s:system_chomp(cmd, v.dir)
       if !empty(diff)
         let ref = has_key(v, 'tag') ? (' (tag: '.v.tag.')') : has_key(v, 'commit') ? (' '.v.commit) : ''
         call append(5, extend(['', '- '.k.':'.ref], map(s:lines(diff), 's:format_git_log(v:val)')))

--- a/plug.vim
+++ b/plug.vim
@@ -2422,7 +2422,7 @@ function! s:diff()
       let range = origin ? '..origin/'.v.branch : 'HEAD@{1}..'
       let cmd = 'git log --graph --color=never '.join(map(['--pretty=format:%x01%h%x01%d%x01%s%x01%cr', range], 's:shellesc(v:val)'))
       if has_key(v, 'rtp')
-        let cmd .= ' -- '.v.rtp
+        let cmd .= ' -- '.s:shellesc(v.rtp)
       endif
       let diff = s:system_chomp(cmd, v.dir)
       if !empty(diff)

--- a/plug.vim
+++ b/plug.vim
@@ -2420,7 +2420,7 @@ function! s:diff()
     call s:append_ul(2, origin ? 'Pending updates:' : 'Last update:')
     for [k, v] in plugs
       let range = origin ? '..origin/'.v.branch : 'HEAD@{1}..'
-      let diff = s:system_chomp('git log --graph --color=never '.join(map(['--pretty=format:%x01%h%x01%d%x01%s%x01%cr', range], 's:shellesc(v:val)')), v.dir)
+      let diff = s:system_chomp('git log --graph --color=never '.join(map(['--pretty=format:%x01%h%x01%d%x01%s%x01%cr', range], 's:shellesc(v:val)')).' -- .', s:rtp(v))
       if !empty(diff)
         let ref = has_key(v, 'tag') ? (' (tag: '.v.tag.')') : has_key(v, 'commit') ? (' '.v.commit) : ''
         call append(5, extend(['', '- '.k.':'.ref], map(s:lines(diff), 's:format_git_log(v:val)')))

--- a/plug.vim
+++ b/plug.vim
@@ -2422,7 +2422,7 @@ function! s:diff()
       let range = origin ? '..origin/'.v.branch : 'HEAD@{1}..'
       let cmd = 'git log --graph --color=never '.join(map(['--pretty=format:%x01%h%x01%d%x01%s%x01%cr', range], 's:shellesc(v:val)'))
       if has_key(v, 'rtp')
-        let cmd .= ' -- ' . v.rtp
+        let cmd .= ' -- '.v.rtp
       endif
       let diff = s:system_chomp(cmd, v.dir)
       if !empty(diff)

--- a/test/workflow.vader
+++ b/test/workflow.vader
@@ -537,6 +537,51 @@ Execute (PlugDiff):
   Assert !empty(mapcheck("\<cr>"))
   q
 
+Execute (Do not show diff for commits outside of rtp):
+  call plug#begin()
+  call plug#end()
+  PlugClean!
+
+  call plug#begin()
+  Plug 'file://'.expand('$PLUG_FIXTURES').'/xxx'
+  Plug 'file://'.expand('$PLUG_FIXTURES').'/yyy', { 'rtp': 'rtp' }
+  call plug#end()
+  PlugInstall
+  Log getline(1, '$')
+
+  call system('cd "$PLUG_FIXTURES/xxx" && git commit --allow-empty -m update-xxx && git tag -f xxx')
+  call system('cd "$PLUG_FIXTURES/yyy" && git commit --allow-empty -m update-yyy && git tag -f yyy')
+
+  let g:plugs.yyy.tag = 'yyy'
+  PlugUpdate
+  Log getline(1, '$')
+
+  PlugDiff
+  " 1 plugin(s) updated.
+  " [==]
+  "
+  " Last update:
+  " ------------
+  "
+  " - xxx:
+  "   * 7faa9b2 update-xxx (0 seconds ago)
+  "
+  " Pending updates:
+  " ----------------
+  "
+  " N/A
+  "
+  Log getline(1, '$')
+  AssertEqual 14, line('$')
+  AssertEqual '1 plugin(s) updated.', getline(1)
+  AssertEqual '[==]', getline(2)
+  AssertEqual 'Last update:', getline(4)
+  AssertEqual '- xxx:', getline(7)
+  Assert !empty(mapcheck('o'))
+  Assert !empty(mapcheck('X'))
+  Assert !empty(mapcheck("\<cr>"))
+  q
+
 **********************************************************************
 ~ On-demand loading / Partial installation/update ~
 **********************************************************************


### PR DESCRIPTION
Previously, `:PlugDiff` would show every new commit to a plugin's git
repo. This makes sense for the general case, but makes less sense when a
plugin lives in a subdirectory of the repo (and is configured with the
'rtp' option). This makes it difficult to determine which commits relate
to the plugin and which are unrelated.

This changes `:PlugDiff` to filter out any commits outside of the 'rtp'
folder.

Some consequences:

 * This does not change the `:PlugUpdate` UI. This means `:PlugUpdate`
   may pull down non-plugin commits, display that it has updated the
   plugin, and then `:PlugDiff` will show no updates (since such commits
   fall out of the 'rtp' path).
 * It also means there's no UI to revert non-plugin updates, as they
   don't show up in `:PlugDiff`.

Fixes #797
Test: Manual on Linux machine