### PR TITLE
Correct installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $uri = 'https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
 ###### Unix
 
 ```sh
-curl -fLo ~/.local/share/nvim/site/autoload/plug.vim --create-dirs \
+curl -fLo ~/.config/nvim/autoload/plug.vim --create-dirs \
     https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 ```
 


### PR DESCRIPTION
In README, the installation command for Neovim and Unix uses another path than in Wiki > Tutorial > Setting up.

The path in README doesn't work for me on a Mac, while the one in Tutorial works.