### PR TITLE
Add GV.vim-style q mapping

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -935,7 +935,7 @@ function! s:prepare(...)
     call s:new_window()
   endif
 
-  nnoremap <silent> <buffer> q  :if b:plug_preview==1<bar>pc<bar>endif<bar>bd<cr>
+  nnoremap <silent> <buffer> q :call <SID>close_pane()<cr>
   if a:0 == 0
     call s:finish_bindings()
   endif
@@ -954,6 +954,15 @@ function! s:prepare(...)
   setf vim-plug
   if exists('g:syntax_on')
     call s:syntax()
+  endif
+endfunction
+
+function! s:close_pane()
+  if b:plug_preview == 1
+    pc
+    let b:plug_preview = -1
+  else
+    bd
   endif
 endfunction
 

--- a/test/workflow.vader
+++ b/test/workflow.vader
@@ -428,12 +428,16 @@ Execute (New commits on remote, PlugUpdate, then PlugDiff):
   execute "normal Xy\<cr>"
   AssertExpect '^- ', 1
 
-  " q will close preview window as well
+  " q will only close preview window
   normal q
 
   " We no longer have preview window
   silent! wincmd P
   AssertEqual 0, &previewwindow
+
+  " And we're still on main vim-plug window
+  AssertEqual 'vim-plug', &filetype
+  normal q
 
   " q should not close preview window if it's already open
   pedit
@@ -459,6 +463,11 @@ Execute (Test g:plug_pwindow):
   AssertEqual 2, winnr()
   AssertEqual 5, winheight('.')
   wincmd p
+
+  " Close preview window
+  normal q
+
+  " Close main window
   normal q
   unlet g:plug_pwindow
 


### PR DESCRIPTION
### Overview
I adapted the q mapping to mimic the behavior of GV.vim's.
This mostly affects PlugDiff and it's commit diff preview window.

### Current behavior:
Hitting q closes PlugDiff's commit preview window and PlugDiff's pane itself.

### New behavior:
If there's a preview window available, hitting q closes it.
If there's no preview window, hitting q closes PlugDiff's pane directly.

EDIT:
Damn. I'll add tests if there's interest in merging this PR.