### PR TITLE
Don't override shell on Windows

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -794,9 +794,7 @@ endfunction
 
 function! s:chsh(swap)
   let prev = [&shell, &shellcmdflag, &shellredir]
-  if s:is_win
-    set shell=cmd.exe shellcmdflag=/c shellredir=>%s\ 2>&1
-  elseif a:swap
+  if !s:is_win && a:swap
     set shell=sh shellredir=>%s\ 2>&1
   endif
   return prev
@@ -811,7 +809,7 @@ function! s:bang(cmd, ...)
     if s:is_win
       let batchfile = tempname().'.bat'
       call writefile(["@echo off\r", cmd . "\r"], batchfile)
-      let cmd = s:shellesc(batchfile)
+      let cmd = s:shellesc(expand(batchfile))
     endif
     let g:_plug_bang = (s:is_win && has('gui_running') ? 'silent ' : '').'!'.escape(cmd, '#!%')
     execute "normal! :execute g:_plug_bang\<cr>\<cr>"
@@ -1210,7 +1208,7 @@ function! s:spawn(name, cmd, opts)
   let cmd = has_key(a:opts, 'dir') ? s:with_cd(a:cmd, a:opts.dir) : a:cmd
   if !empty(job.batchfile)
     call writefile(["@echo off\r", cmd . "\r"], job.batchfile)
-    let cmd = s:shellesc(job.batchfile)
+    let cmd = s:shellesc(expand(job.batchfile))
   endif
   let argv = add(s:is_win ? ['cmd', '/c'] : ['sh', '-c'], cmd)
 
@@ -2037,7 +2035,7 @@ function! s:system(cmd, ...)
     if s:is_win
       let batchfile = tempname().'.bat'
       call writefile(["@echo off\r", cmd . "\r"], batchfile)
-      let cmd = s:shellesc(batchfile)
+      let cmd = s:shellesc(expand(batchfile))
     endif
     return system(cmd)
   finally
@@ -2371,7 +2369,7 @@ function! s:preview_commit()
     if s:is_win
       let batchfile = tempname().'.bat'
       call writefile(["@echo off\r", cmd . "\r"], batchfile)
-      let cmd = batchfile
+      let cmd = expand(batchfile)
     endif
     execute 'silent %!' cmd
   finally


### PR DESCRIPTION
Assume that the user set the shell options correctly before running vim-plug so that the user can use bash or powershell as their shell.

If this works, port the fix to fzf's Vim plugin to resolve related issues. If there's time, avoid the batchfile on Neovim or Vim jobs before porting to fzf.

Close https://github.com/junegunn/vim-plug/issues/815