### PR TITLE
Fix Windows support for Unix shells and powershell

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -810,6 +810,9 @@ function! s:bang(cmd, ...)
       let batchfile = tempname().'.bat'
       call writefile(["@echo off\r", cmd . "\r"], batchfile)
       let cmd = s:shellesc(batchfile, &shell)
+      if &shell =~# 'powershell\.exe$'
+        let cmd = '& ' . cmd
+      endif
     endif
     let g:_plug_bang = (s:is_win && has('gui_running') ? 'silent ' : '').'!'.escape(cmd, '#!%')
     execute "normal! :execute g:_plug_bang\<cr>\<cr>"
@@ -2036,6 +2039,9 @@ function! s:system(cmd, ...)
       let batchfile = tempname().'.bat'
       call writefile(["@echo off\r", cmd . "\r"], batchfile)
       let cmd = s:shellesc(batchfile, &shell)
+      if &shell =~# 'powershell\.exe$'
+        let cmd = '& ' . cmd
+      endif
     endif
     return system(cmd)
   finally
@@ -2370,6 +2376,9 @@ function! s:preview_commit()
       let batchfile = tempname().'.bat'
       call writefile(["@echo off\r", cmd . "\r"], batchfile)
       let cmd = s:shellesc(batchfile, &shell)
+      if &shell =~# 'powershell\.exe$'
+        let cmd = '& ' . cmd
+      endif
     endif
     execute 'silent %!' cmd
   finally

--- a/plug.vim
+++ b/plug.vim
@@ -1206,11 +1206,11 @@ function! s:spawn(name, cmd, opts)
             \ 'new': get(a:opts, 'new', 0) }
   let s:jobs[a:name] = job
   let cmd = has_key(a:opts, 'dir') ? s:with_cd(a:cmd, a:opts.dir) : a:cmd
+  let argv = add(s:is_win ? ['cmd', '/c'] : ['sh', '-c'], cmd)
   if !empty(job.batchfile)
     call writefile(["@echo off\r", cmd . "\r"], job.batchfile)
-    let cmd = s:shellesc(expand(job.batchfile), &shell)
+    let argv = s:vim8 ? 'cmd.exe '.s:shellesc(job.batchfile) : ['cmd.exe', job.batchfile]
   endif
-  let argv = add(s:is_win ? ['cmd', '/c'] : ['sh', '-c'], cmd)
 
   if s:nvim
     call extend(job, {
@@ -1227,7 +1227,7 @@ function! s:spawn(name, cmd, opts)
             \ 'Invalid arguments (or job table is full)']
     endif
   elseif s:vim8
-    let jid = job_start(s:is_win ? join(argv, ' ') : argv, {
+    let jid = job_start(argv, {
     \ 'out_cb':   function('s:job_cb', ['s:job_out_cb',  job]),
     \ 'exit_cb':  function('s:job_cb', ['s:job_exit_cb', job]),
     \ 'out_mode': 'raw'

--- a/plug.vim
+++ b/plug.vim
@@ -1997,8 +1997,7 @@ function! s:shellesc_ps1(arg)
 endfunction
 
 function! plug#shellescape(arg, ...)
-  let opts = get(a:000, 0, {})
-  let opts = type(opts) == s:TYPE.dict ? opts : {}
+  let opts = a:0 > 0 && type(a:1) == s:TYPE.dict ? a:1 : {}
   let shell = get(opts, 'shell', s:is_win ? 'cmd.exe' : 'sh')
   let script = get(opts, 'script', 1)
   if shell =~# 'cmd\.exe$'
@@ -2039,7 +2038,7 @@ function! s:format_message(bullet, name, message)
 endfunction
 
 function! s:with_cd(cmd, dir, ...)
-  let script = get(a:000, 0, 1)
+  let script = a:0 > 0 ? a:1 : 1
   return printf('cd%s %s && %s', s:is_win ? ' /d' : '', plug#shellescape(a:dir, {'script': script}), a:cmd)
 endfunction
 

--- a/plug.vim
+++ b/plug.vim
@@ -809,7 +809,7 @@ function! s:bang(cmd, ...)
     if s:is_win
       let batchfile = tempname().'.bat'
       call writefile(["@echo off\r", cmd . "\r"], batchfile)
-      let cmd = s:shellesc(expand(batchfile))
+      let cmd = s:shellesc(expand(batchfile), &shell)
     endif
     let g:_plug_bang = (s:is_win && has('gui_running') ? 'silent ' : '').'!'.escape(cmd, '#!%')
     execute "normal! :execute g:_plug_bang\<cr>\<cr>"
@@ -1208,7 +1208,7 @@ function! s:spawn(name, cmd, opts)
   let cmd = has_key(a:opts, 'dir') ? s:with_cd(a:cmd, a:opts.dir) : a:cmd
   if !empty(job.batchfile)
     call writefile(["@echo off\r", cmd . "\r"], job.batchfile)
-    let cmd = s:shellesc(expand(job.batchfile))
+    let cmd = s:shellesc(expand(job.batchfile), &shell)
   endif
   let argv = add(s:is_win ? ['cmd', '/c'] : ['sh', '-c'], cmd)
 
@@ -1988,8 +1988,9 @@ function! s:shellesc_cmd(arg)
   return '^"'.substitute(escaped, '\(\\\+\)$', '\1\1', '').'^"'
 endfunction
 
-function! s:shellesc(arg)
-  if &shell =~# 'cmd.exe$'
+function! s:shellesc(arg, ...)
+  let shell = get(a:000, 0, s:is_win ? 'cmd.exe' : 'sh')
+  if shell =~# 'cmd.exe$'
     return s:shellesc_cmd(a:arg)
   endif
   return shellescape(a:arg)
@@ -2035,7 +2036,7 @@ function! s:system(cmd, ...)
     if s:is_win
       let batchfile = tempname().'.bat'
       call writefile(["@echo off\r", cmd . "\r"], batchfile)
-      let cmd = s:shellesc(expand(batchfile))
+      let cmd = s:shellesc(expand(batchfile), &shell)
     endif
     return system(cmd)
   finally
@@ -2369,7 +2370,7 @@ function! s:preview_commit()
     if s:is_win
       let batchfile = tempname().'.bat'
       call writefile(["@echo off\r", cmd . "\r"], batchfile)
-      let cmd = expand(batchfile)
+      let cmd = s:shellesc(expand(batchfile), &shell)
     endif
     execute 'silent %!' cmd
   finally

--- a/plug.vim
+++ b/plug.vim
@@ -2002,8 +2002,7 @@ function! s:shellesc(arg, ...)
   let script = get(opts, 'script', 1)
   if shell =~# 'cmd\.exe$'
     return s:shellesc_cmd(a:arg, script)
-  endif
-  if shell =~# 'powershell\.exe$'
+  elseif shell =~# 'powershell\.exe$'
     return s:shellesc_ps1(a:arg)
   endif
   return shellescape(a:arg)

--- a/plug.vim
+++ b/plug.vim
@@ -1980,10 +1980,17 @@ function! s:shellesc_cmd(arg)
   return '^"'.substitute(escaped, '\(\\\+\)$', '\1\1', '').'^"'
 endfunction
 
+function! s:shellesc_ps1(arg)
+  return "'".substitute(escape(a:arg, '\"'), "'", "''", 'g')."'"
+endfunction
+
 function! s:shellesc(arg, ...)
   let shell = get(a:000, 0, s:is_win ? 'cmd.exe' : 'sh')
-  if shell =~# 'cmd.exe$'
+  if shell =~# 'cmd\.exe$'
     return s:shellesc_cmd(a:arg)
+  endif
+  if shell =~# 'powershell\.exe$'
+    return s:shellesc_ps1(a:arg)
   endif
   return shellescape(a:arg)
 endfunction

--- a/plug.vim
+++ b/plug.vim
@@ -1202,15 +1202,10 @@ endfunction
 
 function! s:spawn(name, cmd, opts)
   let job = { 'name': a:name, 'running': 1, 'error': 0, 'lines': [''],
-            \ 'batchfile': (s:is_win && (s:nvim || s:vim8)) ? tempname().'.bat' : '',
             \ 'new': get(a:opts, 'new', 0) }
   let s:jobs[a:name] = job
   let cmd = has_key(a:opts, 'dir') ? s:with_cd(a:cmd, a:opts.dir) : a:cmd
-  if !empty(job.batchfile)
-    call writefile(["@echo off\r", cmd . "\r"], job.batchfile)
-    let cmd = s:shellesc(job.batchfile)
-  endif
-  let argv = add(s:is_win ? ['cmd', '/c'] : ['sh', '-c'], cmd)
+  let argv = s:is_win ? ['cmd', '/s', '/c', '"'.cmd.'"'] : ['sh', '-c', cmd]
 
   if s:nvim
     call extend(job, {
@@ -1260,9 +1255,6 @@ function! s:reap(name)
   call s:log(bullet, a:name, empty(result) ? 'OK' : result)
   call s:bar()
 
-  if has_key(job, 'batchfile') && !empty(job.batchfile)
-    call delete(job.batchfile)
-  endif
   call remove(s:jobs, a:name)
 endfunction
 

--- a/test/functional.vader
+++ b/test/functional.vader
@@ -1,0 +1,37 @@
+Execute (plug#shellescape() works without optional arguments):
+  if has('unix')
+    AssertEqual "''", plug#shellescape("")
+    AssertEqual "'foo'\\'''", plug#shellescape("foo'")
+  endif
+
+Execute (plug#shellescape() ignores invalid optional argument):
+  if has('unix')
+    AssertEqual "''", plug#shellescape("", '')
+    AssertEqual "'foo'\\'''", plug#shellescape("foo'", [])
+  endif
+
+Execute (plug#shellescape() depends on the shell):
+  AssertEqual "'foo'\\'''", plug#shellescape("foo'", {'shell': 'sh'})
+  AssertEqual '^"foo''^"', plug#shellescape("foo'", {'shell': 'cmd.exe'})
+  AssertEqual "'foo'''", plug#shellescape("foo'", {'shell': 'powershell.exe'})
+  AssertEqual "'foo'''", plug#shellescape("foo'", {'shell': 'pwsh'})
+
+Execute (plug#shellescape() supports non-trivial cmd.exe escaping):
+  " batchfile
+  AssertEqual '^"^^%%PATH^^%%^"', plug#shellescape("^%PATH^%", {
+  \ 'shell': 'cmd.exe',
+  \ })
+  AssertEqual '^"^^%%PATH^^%%^"', plug#shellescape("^%PATH^%", {
+  \ 'shell': 'cmd.exe',
+  \ 'script': 1,
+  \ })
+  " command prompt
+  AssertEqual '^"^^^%PATH^^^%^"', plug#shellescape("^%PATH^%", {
+  \ 'shell': 'cmd.exe',
+  \ 'script': 0,
+  \ }),
+
+Execute (plug#shellescape() supports non-trivial powershell.exe escaping):
+  AssertEqual '''\"Foo\\''''\\Bar\"''', plug#shellescape('"Foo\''\Bar"', {
+  \ 'shell': 'powershell.exe',
+  \ }),

--- a/test/test.vader
+++ b/test/test.vader
@@ -90,6 +90,7 @@ Execute (Print Interpreter Version):
 
 Include: workflow.vader
 Include: regressions.vader
+Include: functional.vader
 
 Execute (Cleanup):
   silent! call RmRf(g:temp_plugged)


### PR DESCRIPTION
Fix #815 
Fix (partial) #690
Fix https://github.com/junegunn/vim-plug/issues/831
Fix https://github.com/junegunn/vim-plug/issues/832 (issue happens on Windows for custom shell settings without this PR)

@mikelue Can you test if it works?

TODO
- [X] powershell
   - require `set noshellslash`, same as cmd.exe
  - fails on `do` hook after installing the repo (tested with `do` hook to install the fzf binary)  
  - `shellredir` must be set to `| Out-File -Encoding utf8` 
- [ ] figure out how to port this to fzf Vim plugin (`fzf#shellescape` uses a different shell default)
- [x] investigate if Vim escapes executable arguments in `job_start([executable, arg1, arg2, ...])` and if it's still broken on cmd.exe, similar to `term_start` behavior.
   - Still broken in 8.1.1794 so the hack in vim-plug should be ported to fzf