### PR TITLE
Travis: add macOS 10.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ matrix:
     - env: ENV=vim74-xenial-ruby
       dist: xenial
       addons: {apt: {packages: [vim-nox]}}
+    - env: ENV=osx-10.14
+      os: osx
+      osx_image: xcode10.2
 install: |
   git config --global user.email "you@example.com"
   git config --global user.name "Your Name"


### PR DESCRIPTION
I don't have a mac to verify that my changes don't introduce any regressions.

Ref: https://github.com/junegunn/vim-plug/pull/860#issuecomment-521964314

`osx_image` (https://docs.travis-ci.com/user/reference/osx/#macos-version) should be recent enough to avoid outdated homebrew packages because Travis may take 5-10 mins updating homebrew.