### PR TITLE
Travis: use default image for osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ matrix:
     - env: ENV=vim74-xenial-ruby
       dist: xenial
       addons: {apt: {packages: [vim-nox]}}
-    - env: ENV=osx-10.14
+    - env: ENV=osx-highsierra
       os: osx
-      osx_image: xcode10.2
+      osx_image: xcode9.4
 install: |
   git config --global user.email "you@example.com"
   git config --global user.name "Your Name"


### PR DESCRIPTION
Fix https://travis-ci.org/junegunn/vim-plug/jobs/573145961#L211-L217

~~I haven't had this issue when using rvm with system ruby on osx.
Supported ruby versions, based on commits from `git log src/if_ruby.c` of vim source, is >=1.8, <=2.6.~~ The issue is with Mojave. Using an older osx image fixes the issue. I used the default image because it uses High Sierra.