### PR TITLE
Include function to check if plugin is loaded

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -2260,6 +2260,10 @@ function! s:upgrade_specs()
   endfor
 endfunction
 
+function! plug#is_loaded(name)
+    return has_key(s:loaded, a:name)
+endfunction
+
 function! s:status()
   call s:prepare()
   call append(0, 'Checking plugins')


### PR DESCRIPTION
Simple public function that checks whether a plugin is loaded.

Fixes #849 

This allows me to do a snippet lower in my init.vim such as:

```
if plug#is_loaded('NeoSolarized')
    colorscheme NeoSolarized
endif
```

(I'm more than open to modifying this if needed, but thought a little code was a good start to the PR process.)
