### PR TITLE
output of chcp was not parsed correctly

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -353,9 +353,9 @@ if s:is_win
 
   " Copied from fzf
   function! s:wrap_cmds(cmds)
-    return map(['@echo off', 'for /f "delims=: tokens=2" %%a in (''chcp'') do set origchcp=%%a', 'set origchcp=%origchcp: =%', 'chcp 65001 > nul'] +
+    return map(['@echo off','setlocal enabledelayedexpansion','for /f "delims=: tokens=2" %%a in (''chcp'') do set origchcp=%%a','set origchcp=!origchcp: =!','chcp 65001 > nul'] +
     \ (type(a:cmds) == type([]) ? a:cmds : [a:cmds]) +
-    \ ['chcp %origchcp% > nul'], 'v:val."\r"')
+    \ ['chcp !origchcp! > nul','setlocal disabledelayedexpansion'],'v:val."\r"')
   endfunction
 
   function! s:batchfile(cmd)

--- a/plug.vim
+++ b/plug.vim
@@ -353,7 +353,7 @@ if s:is_win
 
   " Copied from fzf
   function! s:wrap_cmds(cmds)
-    return map(['@echo off', 'for /f "tokens=4" %%a in (''chcp'') do set origchcp=%%a', 'chcp 65001 > nul'] +
+    return map(['@echo off', 'for /f "delims=: tokens=2" %%a in (''chcp'') do set origchcp=%%a', 'set origchcp=%origchcp: =%', 'chcp 65001 > nul'] +
     \ (type(a:cmds) == type([]) ? a:cmds : [a:cmds]) +
     \ ['chcp %origchcp% > nul'], 'v:val."\r"')
   endfunction


### PR DESCRIPTION
On Windows, when wrapping a batch command with the function s:wrap_cmds(),
when calling 'chcp' to get the current code page, the code assumed that
the output was in the format "active code page: XXX" (where XXX is the
code page), whereas the actual output is localized (for instance, in
French, the output would be: "page de code active: XXX").
The parsing of the output relied on that, and this failed for a
message different from "active code page" (i.e., English).

This patch changes the parsing to split the output of chcp on the colon
instead of spaces. Assuming that the output is always in the format
"localized message: XXX", regardless of the locale, hopefully, this is
a bit more robust.