### PR TITLE
Detect WSL (Neovim only)

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -1028,7 +1028,7 @@ function! s:update_impl(pull, force, args) abort
   let s:clone_opt = get(g:, 'plug_shallow', 1) ?
         \ '--depth 1' . (s:git_version_requirement(1, 7, 10) ? ' --no-single-branch' : '') : ''
 
-  if has('win32unix')
+  if has('win32unix') || has('wsl')
     let s:clone_opt .= ' -c core.eol=lf -c core.autocrlf=input'
   endif
 


### PR DESCRIPTION
Works since Neovim v0.3.0 (https://github.com/neovim/neovim/commit/5d2dd2ebe28c31f223d77355a8f9d40adfb41c82)

Fix: https://github.com/junegunn/vim-plug/issues/821

This shouldn't be necessary because the user can configure `git` to use `LF` but there is a check for cygwin/mingw/msys2 vim via `has('win32unix')`.