### PR TITLE
Use chcp only if sed is in PATH

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -353,14 +353,16 @@ if s:is_win
 
   " Copied from fzf
   function! s:wrap_cmds(cmds)
+    let use_chcp = executable('sed')
     return map([
       \ '@echo off',
-      \ 'setlocal enabledelayedexpansion',
-      \ 'for /f "tokens=*" %%a in (''chcp'') do for %%b in (%%a) do set origchcp=%%b',
-      \ 'chcp 65001 > nul'
-    \ ]
+      \ 'setlocal enabledelayedexpansion']
+    \ + (use_chcp ? [
+      \ 'for /f "usebackq" %%a in (`chcp ^| sed "s/[^0-9]//gp"`) do set origchcp=%%a',
+      \ 'chcp 65001 > nul'] : [])
     \ + (type(a:cmds) == type([]) ? a:cmds : [a:cmds])
-    \ + ['chcp !origchcp! > nul', 'endlocal'],
+    \ + (use_chcp ? ['chcp !origchcp! > nul'] : [])
+    \ + ['endlocal'],
     \ 'v:val."\r"')
   endfunction
 


### PR DESCRIPTION
Fix https://github.com/junegunn/vim-plug/issues/884

`sed` is now required to parse `chcp` output. Vim can be used instead via separate child `system` call but doing it per `s:system` makes Windows slower. `chcp` parsing is fragile because of the system locale. There's no convenient way to parse out the codepage value without regex just by relying on cmd.exe builtins and default binaries in `PATH`.
If this still doesn't work, users will have to get by with ascii output only (no readable unicode symbols from console) because this is a OS problem. This applies to fzf as well because the chcp code orignated from fzf Vim plugin was meant for UTF-8 characters.

Powershell builtins could be used as an alternative to sed but using powershell on non-powershell `&shell` slows down `s:system`.