### PR TITLE
Don't use chcp.

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -182,6 +182,11 @@ function! s:define_commands()
   \ && (&shell =~# 'cmd\.exe' || &shell =~# 'powershell\.exe')
     return s:err('vim-plug does not support shell, ' . &shell . ', when shellslash is set.')
   endif
+  if !has('nvim')
+    \ && (has('win32') || has('win32unix'))
+    \ && (!has('multi_byte') || !has('iconv'))
+    return s:err('Vim needs +iconv, +multi_byte features on Windows to run shell commands.')
+  endif
   command! -nargs=* -bar -bang -complete=customlist,s:names PlugInstall call s:install(<bang>0, [<f-args>])
   command! -nargs=* -bar -bang -complete=customlist,s:names PlugUpdate  call s:update(<bang>0, [<f-args>])
   command! -nargs=0 -bar -bang PlugClean call s:clean(<bang>0)
@@ -395,18 +400,14 @@ if s:is_win
   endfunction
 
   " Copied from fzf
+  let s:codepage = libcallnr('kernel32.dll', 'GetACP', 0)
   function! s:wrap_cmds(cmds)
-    let use_chcp = executable('sed')
     return map([
       \ '@echo off',
       \ 'setlocal enabledelayedexpansion']
-    \ + (use_chcp ? [
-      \ 'for /f "usebackq" %%a in (`chcp ^| sed "s/[^0-9]//gp"`) do set origchcp=%%a',
-      \ 'chcp 65001 > nul'] : [])
     \ + (type(a:cmds) == type([]) ? a:cmds : [a:cmds])
-    \ + (use_chcp ? ['chcp !origchcp! > nul'] : [])
     \ + ['endlocal'],
-    \ 'v:val."\r"')
+    \ printf('iconv(v:val."\r", "%s", "cp%d")', &encoding, s:codepage))
   endfunction
 
   function! s:batchfile(cmd)


### PR DESCRIPTION
User should fix their terminal font to display unicode characters.
Terminal programs can only use Wide String APIs.
For Vim, this requires +multi_byte feature ~~and `set encoding=utf-8`
in the user's vimrc.~~ `iconv()` and `libcallnr` to get the current codepage (can this be cached?).
Neovim always defaults to `set encoding=utf-8`.

~~vim-plug runs commands in a batchfile with utf-8 characters.
On terminal Vim, run the batchfile in a separate minimized console
to not break the terminal console.~~

https://dev.to/mattn/please-stop-hack-chcp-65001-27db

cc @mattn @junegunn 

Close https://github.com/junegunn/vim-plug/issues/908