### PR TITLE
Do not show git signatures in diff window

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -2482,7 +2482,9 @@ function! s:diff()
     call s:append_ul(2, origin ? 'Pending updates:' : 'Last update:')
     for [k, v] in plugs
       let range = origin ? '..origin/'.v.branch : 'HEAD@{1}..'
-      let cmd = 'git log --graph --color=never '.join(map(['--pretty=format:%x01%h%x01%d%x01%s%x01%cr', range], 'plug#shellescape(v:val)'))
+      let cmd = 'git log --graph --color=never '
+      \ . (s:git_version_requirement(2, 10, 0) ? '--no-show-signature ' : '')
+      \ . join(map(['--pretty=format:%x01%h%x01%d%x01%s%x01%cr', range], 'plug#shellescape(v:val)'))
       if has_key(v, 'rtp')
         let cmd .= ' -- '.plug#shellescape(v.rtp)
       endif

--- a/test/workflow.vader
+++ b/test/workflow.vader
@@ -354,6 +354,7 @@ Execute (New commits on remote, PlugUpdate, then PlugDiff):
   " Now we have updates
   normal D
   AssertEqual '2 plugin(s) updated.', getline(1)
+  AssertThrows execute('/gpg')
 
   " Preview commit
   silent! wincmd P


### PR DESCRIPTION
git v2.10.0 adds "log.showSignature" config
so that "git log --show-signature" runs by default.
Changing the commit format via "--pretty" does not prevent the signature
from appearing.
Only "--no-show-signature" prevents this.

Close #728