### PR TITLE
Validate last buffer line of g:plug_window

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -1338,9 +1338,10 @@ function! s:bar()
 endfunction
 
 function! s:logpos(name)
-  for i in range(4, line('$'))
+  let max = line('$')
+  for i in range(4, max > 4 ? max : 4)
     if getline(i) =~# '^[-+x*] '.a:name.':'
-      for j in range(i + 1, line('$'))
+      for j in range(i + 1, max > 5 ? max : 5)
         if getline(j) !~ '^ '
           return [i, j - 1]
         endif


### PR DESCRIPTION
Close #926

This fix shouldn't be necessary
because vim-plug's buffer should always have 4 lines
but a buffer can be modified in some cases
before nvim 0.4.0 and vim v8.1.1360.

cc @GopherJ 