### PR TITLE
Fix fatal invalid reference for repos have no tags

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -1158,7 +1158,7 @@ function! s:update_finish()
       if has_key(spec, 'commit')
         call s:log4(name, 'Checking out '.spec.commit)
         let out = s:checkout(spec)
-      elseif has_key(spec, 'tag')
+      elseif has_key(spec, 'tag') && spec.tag
         let tag = spec.tag
         if tag =~ '\*'
           let tags = s:lines(s:system('git tag --list '.plug#shellescape(tag).' --sort -version:refname 2>&1', spec.dir))


### PR DESCRIPTION
<!-- ## Before Submitting

- You made sure the existing tests/travis build works.
- You made sure any new features were tested where appropriate.
- You checked a similar feature wasn't already turned down by searching issues & PRs.
-->

If a repo (such as [is.vim](https://github.com/haya14busa/is.vim)) has no tags , when invoke `:PlugUpdate`, it will occur `fatal invalid reference`.

The patch will skip tags check for this case.
