### PR TITLE
Clarify error message

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -251,7 +251,7 @@ endfunction
 
 function! plug#end()
   if !exists('g:plugs')
-    return s:err('Call plug#begin() first')
+    return s:err('plug#end() called without calling plug#begin() first')
   endif
 
   if exists('#PlugLOD')

--- a/test/workflow.vader
+++ b/test/workflow.vader
@@ -2,7 +2,7 @@ Execute (plug#end() before plug#begin() should fail):
   redir => out
   silent! AssertEqual 0, plug#end()
   redir END
-  Assert stridx(out, 'Call plug#begin() first') >= 0
+  Assert stridx(out, 'plug#end() called without calling plug#begin() first') >= 0
 
 Execute (plug#begin() without path argument):
   call plug#begin()


### PR DESCRIPTION
The existing error message printed when `plug#end()` is called without calling `plug#begin()` doesn't make the dependence on `plug#begin()` obvious; I had to go digging in the vim-plug code to discover what I'd done wrong. This attempts to clarify the error a bit, to make it more obvious to a user.