### PR TITLE
Fast git

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -251,7 +251,7 @@ endfunction
 
 function! plug#end()
   if !exists('g:plugs')
-    return s:err('Call plug#begin() first')
+    return s:err('plug#end() called without calling plug#begin() first')
   endif
 
   if exists('#PlugLOD')

--- a/plug.vim
+++ b/plug.vim
@@ -2226,7 +2226,7 @@ function! s:git_validate(spec, check_branch)
   if isdirectory(a:spec.dir)
     let result = [s:git_get_branch(a:spec.dir), s:git_get_remote_origin_url(a:spec.dir)]
     let remote = result[-1]
-    if type(remote) ==# v:t_null
+    if empty(remote)
       let err = join([remote, 'PlugClean required.'], "\n")
     elseif !s:compare_git_uri(remote, a:spec.uri)
       let err = join(['Invalid URI: '.remote,
@@ -2234,7 +2234,7 @@ function! s:git_validate(spec, check_branch)
                     \ 'PlugClean required.'], "\n")
     elseif a:check_branch && has_key(a:spec, 'commit')
       let sha = s:git_get_revision(a:spec.dir)
-      if type(sha) == v:t_null
+      if empty(sha)
         let err = join(add(result, 'PlugClean required.'), "\n")
       elseif !s:hash_match(sha, a:spec.commit)
         let err = join([printf('Invalid HEAD (expected: %s, actual: %s)',

--- a/plug.vim
+++ b/plug.vim
@@ -2226,13 +2226,17 @@ function! s:git_validate(spec, check_branch)
   if isdirectory(a:spec.dir)
     let result = [s:git_get_branch(a:spec.dir), s:git_get_remote_origin_url(a:spec.dir)]
     let remote = result[-1]
-    if !s:compare_git_uri(remote, a:spec.uri)
+    if type(remote) ==# v:t_null
+      let err = join([remote, 'PlugClean required.'], "\n")
+    elseif !s:compare_git_uri(remote, a:spec.uri)
       let err = join(['Invalid URI: '.remote,
                     \ 'Expected:    '.a:spec.uri,
                     \ 'PlugClean required.'], "\n")
     elseif a:check_branch && has_key(a:spec, 'commit')
-      let sha = [s:git_get_revision(a:spec.dir)]
-      if !s:hash_match(sha, a:spec.commit)
+      let sha = s:git_get_revision(a:spec.dir)
+      if type(sha) == v:t_null
+        let err = join(add(result, 'PlugClean required.'), "\n")
+      elseif !s:hash_match(sha, a:spec.commit)
         let err = join([printf('Invalid HEAD (expected: %s, actual: %s)',
                               \ a:spec.commit[:6], sha[:6]),
                       \ 'PlugUpdate required.'], "\n")

--- a/plug.vim
+++ b/plug.vim
@@ -144,7 +144,7 @@ endfunction
 function! s:git_get_remote_origin_url(dir) abort
   let gitdir = s:get_gitdir(a:dir)
   if gitdir ==# ''
-    return v:null
+    return ''
   endif
   try
     let lines = readfile(gitdir . '/config')
@@ -171,14 +171,14 @@ function! s:git_get_remote_origin_url(dir) abort
     endwhile
     return url
   catch
-    return v:null
+    return ''
   endtry
 endfunction
 
 function! s:git_get_revision(dir) abort
   let l:gitdir = s:get_gitdir(a:dir)
   if l:gitdir ==# ''
-    return v:null
+    return ''
   endif
   try
     let l:line = readfile(l:gitdir . '/HEAD')[0]
@@ -195,13 +195,13 @@ function! s:git_get_revision(dir) abort
     endif
   catch
   endtry
-  return v:null
+  return ''
 endfunction
 
 function! s:git_get_branch(dir) abort
   let l:gitdir = s:get_gitdir(a:dir)
   if l:gitdir ==# ''
-    return v:null
+    return ''
   endif
   try
     let l:line = readfile(l:gitdir . '/HEAD')[0]
@@ -210,7 +210,7 @@ function! s:git_get_branch(dir) abort
     endif
     return ''
   catch
-    return v:null
+    return ''
   endtry
 endfunction
 

--- a/plug.vim
+++ b/plug.vim
@@ -143,36 +143,11 @@ endfunction
 
 function! s:git_get_remote_origin_url(dir) abort
   let gitdir = s:get_gitdir(a:dir)
-  if gitdir ==# ''
+  let config = gitdir . '/config'
+  if empty(gitdir) || !filereadable(config)
     return ''
   endif
-  try
-    let lines = readfile(gitdir . '/config')
-    let [n, ll, url] = [0, len(lines), '']
-    while n < ll
-      let line = s:trim(lines[n])
-      if stridx(line, '[remote "origin"]') != 0
-        let n += 1
-        continue
-      endif
-      let n += 1
-      while n < ll
-        let line = s:trim(lines[n])
-        if line ==# '['
-          break
-        endif
-        let url = matchstr(line, '^url\s*=\s*\zs[^ #]\+')
-        if !empty(url)
-          break
-        endif
-        let n += 1
-      endwhile
-      let n += 1
-    endwhile
-    return url
-  catch
-    return ''
-  endtry
+  return matchstr(join(readfile(config)), '\[remote "origin"\].\{-}url\s*=\s*\zs\S*\ze')
 endfunction
 
 function! s:git_get_revision(dir) abort

--- a/plug.vim
+++ b/plug.vim
@@ -2336,7 +2336,7 @@ function! s:git_validate(spec, check_branch)
                 \ (empty(tag) ? 'N/A' : tag), a:spec.tag)
         endif
       " Check branch
-      elseif a:spec.branch !=# branch
+      elseif a:spec.branch != '' && a:spec.branch !=# branch
         let err = printf('Invalid branch: %s (expected: %s). Try PlugUpdate.',
               \ branch, a:spec.branch)
       endif

--- a/plug.vim
+++ b/plug.vim
@@ -121,19 +121,19 @@ function! s:isabsolute(dir) abort
 endfunction
 
 function! s:get_gitdir(dir) abort
-  let l:gitdir = a:dir . '/.git'
-  if isdirectory(l:gitdir)
-    return l:gitdir
+  let gitdir = a:dir . '/.git'
+  if isdirectory(gitdir)
+    return gitdir
   endif
   try
-    let l:line = readfile(l:gitdir)[0]
-    if l:line =~# '^gitdir: '
-      let l:gitdir = l:line[8:]
-      if !s:isabsolute(l:gitdir)
-        let l:gitdir = a:dir . '/' . l:gitdir
+    let line = readfile(gitdir)[0]
+    if line =~# '^gitdir: '
+      let gitdir = line[8:]
+      if !s:isabsolute(gitdir)
+        let gitdir = a:dir . '/' . gitdir
       endif
-      if isdirectory(l:gitdir)
-        return l:gitdir
+      if isdirectory(gitdir)
+        return gitdir
       endif
     endif
   catch
@@ -150,14 +150,14 @@ function! s:git_get_remote_origin_url(dir) abort
     let lines = readfile(gitdir . '/config')
     let [n, ll, url] = [0, len(lines), '']
     while n < ll
-      let line = trim(lines[n])
+      let line = s:trim(lines[n])
       if stridx(line, '[remote "origin"]') != 0
         let n += 1
         continue
       endif
       let n += 1
       while n < ll
-        let line = trim(lines[n])
+        let line = s:trim(lines[n])
         if line ==# '['
           break
         endif
@@ -176,20 +176,20 @@ function! s:git_get_remote_origin_url(dir) abort
 endfunction
 
 function! s:git_get_revision(dir) abort
-  let l:gitdir = s:get_gitdir(a:dir)
-  if l:gitdir ==# ''
+  let gitdir = s:get_gitdir(a:dir)
+  if gitdir ==# ''
     return ''
   endif
   try
-    let l:line = readfile(l:gitdir . '/HEAD')[0]
-    if l:line =~# '^ref: '
-      let l:ref = l:line[5:]
-      if filereadable(l:gitdir . '/' . l:ref)
-        return readfile(l:gitdir . '/' . l:ref)[0]
+    let line = readfile(gitdir . '/HEAD')[0]
+    if line =~# '^ref: '
+      let ref = line[5:]
+      if filereadable(gitdir . '/' . ref)
+        return readfile(gitdir . '/' . ref)[0]
       endif
-      for l:line in readfile(l:gitdir . '/packed-refs')
-        if l:line =~# ' ' . l:ref
-          return substitute(l:line, '^\([0-9a-f]*\) ', '\1', '')
+      for line in readfile(gitdir . '/packed-refs')
+        if line =~# ' ' . ref
+          return substitute(line, '^\([0-9a-f]*\) ', '\1', '')
         endif
       endfor
     endif
@@ -199,14 +199,14 @@ function! s:git_get_revision(dir) abort
 endfunction
 
 function! s:git_get_branch(dir) abort
-  let l:gitdir = s:get_gitdir(a:dir)
-  if l:gitdir ==# ''
+  let gitdir = s:get_gitdir(a:dir)
+  if gitdir ==# ''
     return ''
   endif
   try
-    let l:line = readfile(l:gitdir . '/HEAD')[0]
-    if l:line =~# '^ref: refs/heads/'
-      return l:line[16:]
+    let line = readfile(gitdir . '/HEAD')[0]
+    if line =~# '^ref: refs/heads/'
+      return line[16:]
     endif
     return ''
   catch

--- a/plug.vim
+++ b/plug.vim
@@ -2343,7 +2343,7 @@ function! s:git_validate(spec, check_branch)
       if empty(err)
         let result = split(s:lastline(s:system(printf(
                 \ 'git rev-list --count --left-right HEAD...origin/%s',
-                \ a:spec.branch), a:spec.dir)), '\t')
+                \ branch), a:spec.dir)), '\t')
         if !v:shell_error && len(result) == 2
           let [ahead, behind] = result
           if ahead
@@ -2352,11 +2352,11 @@ function! s:git_validate(spec, check_branch)
               " pushable (and probably not that messed up).
               let err = printf(
                     \ "Diverged from origin/%s (%d commit(s) ahead and %d commit(s) behind!\n"
-                    \ .'Backup local changes and run PlugClean and PlugUpdate to reinstall it.', a:spec.branch, ahead, behind)
+                    \ .'Backup local changes and run PlugClean and PlugUpdate to reinstall it.', branch, ahead, behind)
             else
               let err = printf("Ahead of origin/%s by %d commit(s).\n"
                     \ .'Cannot update until local changes are pushed.',
-                    \ a:spec.branch, ahead)
+                    \ branch, ahead)
             endif
           endif
         endif

--- a/plug.vim
+++ b/plug.vim
@@ -2756,7 +2756,7 @@ function! s:snapshot(force, ...) abort
   let names = sort(keys(filter(copy(g:plugs),
         \'has_key(v:val, "uri") && !has_key(v:val, "commit") && isdirectory(v:val.dir)')))
   for name in reverse(names)
-    let sha = s:git_get_revision(g:plugs[name].dir)[:6]
+    let sha = s:git_get_revision(g:plugs[name].dir)
     if !empty(sha)
       call append(anchor, printf("silent! let g:plugs['%s'].commit = '%s'", name, sha))
       redraw

--- a/test/workflow.vader
+++ b/test/workflow.vader
@@ -2,7 +2,7 @@ Execute (plug#end() before plug#begin() should fail):
   redir => out
   silent! AssertEqual 0, plug#end()
   redir END
-  Assert stridx(out, 'Call plug#begin() first') >= 0
+  Assert stridx(out, 'plug#end() called without calling plug#begin() first') >= 0
 
 Execute (plug#begin() without path argument):
   call plug#begin()


### PR DESCRIPTION
When using many plugins, vim-plug spawn many git processes for them.

* get revision
* get branch
* get remote.origin.url

This is too heavy. especially on Windows. This change get revision, branch,
remote origin url directly from .git directory.

This idea is borrowed from @k-takata's [commit](https://github.com/k-takata/minpac/commit/fd782552a996b7d5415e5713f5a11843ce2ff189) for minpac [devel branch](https://github.com/k-takata/minpac/tree/devel).

Before
![screenshot](https://user-images.githubusercontent.com/10111/74900074-046a2180-53e2-11ea-90b5-45c9f4299436.gif)
After
![screenshot](https://user-images.githubusercontent.com/10111/74900121-2c598500-53e2-11ea-91d0-b3a3db6b2ac4.gif)
