### PR TITLE
Add |:Plug| tag in help docs

### DIFF
--- a/doc/plug.txt
+++ b/doc/plug.txt
@@ -204,6 +204,7 @@ Reload .vimrc and `:PlugInstall` to install plugins.
 
 < Plug options >______________________________________________________________~
                                                                   *plug-options*
+                                                                         *:Plug*
 
  ------------------------+-----------------------------------------------
  Option                  | Description                                   ~


### PR DESCRIPTION
This makes it so you can do `:help :Plug` and jump to the correct help docs for the :Plug command.