### PR TITLE
improved path creation in powershell readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,11 @@ file as suggested [here][auto].
 ###### Windows (PowerShell)
 
 ```powershell
-md ~\vimfiles\autoload
+New-Item ${env:USERPROFILE}\vimfiles\autoload -ItemType Directory -Force
 $uri = 'https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
 (New-Object Net.WebClient).DownloadFile(
   $uri,
-  $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath(
-    "~\vimfiles\autoload\plug.vim"
-  )
+  "${env:USERPROFILE}\vimfiles\autoload\plug.vim"
 )
 ```
 


### PR DESCRIPTION
I have removed the `mkdir` alias in powershell which breaks the example in the readme since `md` seems to execute `mkdir`. Furthermore using full function names, e.g. `New-Item` instead of md, is preferred so situations such as this do not happen. I have also replaced the `GetUnresolvedProviderPathFromPSPath` call with using the `USERPROFILE` environment variable.

Note that `-Force` for directories makes sure that _all_ missing directories are created and does __not__ delete existing directories.