### PR TITLE
Comply with the XDG protocol in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ $uri = 'https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
 ###### Unix
 
 ```sh
-curl -fLo ~/.local/share/nvim/site/autoload/plug.vim --create-dirs \
-    https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+sh -c 'curl -fLo "${XDG_DATA_HOME:-$HOME/.local/share}"/nvim/site/autoload/plug.vim --create-dirs \
+       https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
 ```
 
 ###### Windows (PowerShell)
@@ -308,4 +308,3 @@ The commands with `!` suffix ensure that all steps are run unconditionally.
 ### License
 
 MIT
-


### PR DESCRIPTION
The installation instructions in the `README.md` aren't taking into account the XDG specifications. Since `nvim` complies with them, placing `vim-plug`'s code in the default `~/.local/share` directory wouldn't work in case the user has `XDG_DATA_HOME` explicitly set to something else.

The command is wrapped in `sh -c ''` to ensure it's run in a POSIX shell, otherwise it wouldn't work in say, Fish, because of the variable expansion.
Last line was removed upon save because I have my `nvim` set to strip blank lines off the end of the file :slightly_smiling_face: 