### PR TITLE
Install to nvim-data directory on windows for consistency with unix

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $uri = 'https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
 (New-Object Net.WebClient).DownloadFile(
   $uri,
   $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath(
-    "~\AppData\Local\nvim\autoload\plug.vim"
+    "~\AppData\Local\nvim-data\site\autoload\plug.vim"
   )
 )
 ```


### PR DESCRIPTION
For consistency with unix, vim-plug should be installed to 

`~/AppData/Local/nvim-data/site/autoload` (= `~/.local/share/nvim/site/autoload/`) on windows.

`~/AppData/Local/nvim/autoload` is the equivalent of `~/.config/nvim/autoload`