### PR TITLE
Report when PlugClean fails to remove a directory

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -2271,7 +2271,7 @@ endfunction
 
 function! s:rm_rf(dir)
   if isdirectory(a:dir)
-    call s:system(s:is_win
+    return s:system(s:is_win
     \ ? 'rmdir /S /Q '.plug#shellescape(a:dir)
     \ : ['rm', '-rf', a:dir])
   endif
@@ -2355,6 +2355,7 @@ endfunction
 function! s:delete(range, force)
   let [l1, l2] = a:range
   let force = a:force
+  let err_count = 0
   while l1 <= l2
     let line = getline(l1)
     if line =~ '^- ' && isdirectory(line[2:])
@@ -2363,11 +2364,22 @@ function! s:delete(range, force)
       let answer = force ? 1 : s:ask('Delete '.line[2:].'?', 1)
       let force = force || answer > 1
       if answer
-        call s:rm_rf(line[2:])
+        let err = s:rm_rf(line[2:])
         setlocal modifiable
-        call setline(l1, '~'.line[1:])
-        let s:clean_count += 1
-        call setline(4, printf('Removed %d directories.', s:clean_count))
+        if empty(err)
+          call setline(l1, '~'.line[1:])
+          let s:clean_count += 1
+          let msg = printf('Removed %d directories.', s:clean_count)
+          if err_count > 0
+            msg .= printf('Failed to remove %d directories.', err_count)
+          endif
+          call setline(4, msg)
+        else
+          delete
+          call append(l1 - 1, s:format_message('x', line[1:], err))
+          let l2 += len(s:lines(err))
+          let err_count += 1
+        endif
         setlocal nomodifiable
       endif
     endif

--- a/plug.vim
+++ b/plug.vim
@@ -2369,17 +2369,17 @@ function! s:delete(range, force)
         if empty(err)
           call setline(l1, '~'.line[1:])
           let s:clean_count += 1
-          let msg = printf('Removed %d directories.', s:clean_count)
-          if err_count > 0
-            msg .= printf('Failed to remove %d directories.', err_count)
-          endif
-          call setline(4, msg)
         else
           delete
           call append(l1 - 1, s:format_message('x', line[1:], err))
           let l2 += len(s:lines(err))
           let err_count += 1
         endif
+        let msg = printf('Removed %d directories.', s:clean_count)
+        if err_count > 0
+          let msg .= printf(' Failed to remove %d directories.', err_count)
+        endif
+        call setline(4, msg)
         setlocal nomodifiable
       endif
     endif

--- a/plug.vim
+++ b/plug.vim
@@ -2370,7 +2370,7 @@ function! s:delete(range, force)
           call setline(l1, '~'.line[1:])
           let s:clean_count += 1
         else
-          delete
+          delete _
           call append(l1 - 1, s:format_message('x', line[1:], err))
           let l2 += len(s:lines(err))
           let err_count += 1

--- a/test/run
+++ b/test/run
@@ -91,6 +91,11 @@ DOC
   echo "echomsg 'ftplugin-c'" > "$PLUG_FIXTURES/ftplugin-msg/ftplugin/c.vim"
   echo "echomsg 'ftplugin-java'" > "$PLUG_FIXTURES/ftplugin-msg/ftplugin/java.vim"
 
+  chmod +w "$PLUG_FIXTURES/cant-delete/autoload" || rm -rf "$PLUG_FIXTURES/cant-delete"
+  mkdir -p "$PLUG_FIXTURES/cant-delete/autoload"
+  touch "$PLUG_FIXTURES/cant-delete/autoload/cant-delete.vim"
+  chmod -w "$PLUG_FIXTURES/cant-delete/autoload"
+
   rm -rf $TEMP/new-branch
   cd $TEMP
   git init new-branch

--- a/test/workflow.vader
+++ b/test/workflow.vader
@@ -1468,6 +1468,7 @@ Execute (PlugClean should not try to remove unmanaged plugins inside g:plug_home
   Plug '$PLUG_FIXTURES/fzf'
   Plug '$PLUG_FIXTURES/xxx'
   Plug '$PLUG_FIXTURES/yyy'
+  Plug '$PLUG_FIXTURES/cant-delete'
   call plug#end()
 
   " Remove z1, z2
@@ -1721,3 +1722,25 @@ Execute (#766 - Allow cloning into an empty directory):
   AssertExpect! '[=]', 1
   q
   unlet d
+
+Execute (#982 - PlugClean should report when directories cannot be removed):
+  call plug#begin('$PLUG_FIXTURES')
+  Plug '$PLUG_FIXTURES/ftplugin-msg', { 'for': [] }
+  Plug '$PLUG_FIXTURES/fzf'
+  Plug '$PLUG_FIXTURES/xxx'
+  Plug '$PLUG_FIXTURES/yyy'
+  call plug#end()
+
+  " Fail to remove cant-delete
+  PlugClean!
+  AssertEqual 'Removed 0 directories. Failed to remove 1 directories.', getline(4)
+  AssertExpect '^x ', 1
+  q
+
+  " Delete tmp but fail to remove cant-delete
+  call mkdir(expand('$PLUG_FIXTURES/tmp'))
+  PlugClean!
+  AssertEqual 'Removed 1 directories. Failed to remove 1 directories.', getline(4)
+  AssertExpect '^x ', 1
+  AssertExpect '^\~ ', 1
+  q


### PR DESCRIPTION
<!-- ## Before Submitting

- You made sure the existing tests/travis build works.
- You made sure any new features were tested where appropriate.
- You checked a similar feature wasn't already turned down by searching issues & PRs.
-->

Checks the result of `s:rm_rf` and lists directories that could not be removed along with the reason. Fixes #982.

- [X] Passes existing tests
- [x] Wrote new tests
