### PR TITLE
Update README.md (Powershell Install One-Liner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,8 @@ file as suggested [here][auto].
 ###### Windows (PowerShell)
 
 ```powershell
-md ~\vimfiles\autoload
-$uri = 'https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
-(New-Object Net.WebClient).DownloadFile(
-  $uri,
-  $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath(
-    "~\vimfiles\autoload\plug.vim"
-  )
-)
+iwr -useb https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim |`
+    ni $HOME/vimfiles/autoload/plug.vim -Force
 ```
 
 #### Neovim
@@ -73,14 +67,8 @@ curl -fLo ~/.var/app/io.neovim.nvim/data/nvim/site/autoload/plug.vim \
 ###### Windows (PowerShell)
 
 ```powershell
-md ~\AppData\Local\nvim-data\site\autoload
-$uri = 'https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
-(New-Object Net.WebClient).DownloadFile(
-  $uri,
-  $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath(
-    "~\AppData\Local\nvim-data\site\autoload\plug.vim"
-  )
-)
+iwr -useb https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim |`
+    ni $HOME/AppData/Local/nvim-data/site/autoload/plug.vim -Force
 ```
 
 ### Getting Help

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ curl -fLo ~/.var/app/io.neovim.nvim/data/nvim/site/autoload/plug.vim \
 
 ```powershell
 iwr -useb https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim |`
-    ni $HOME/AppData/Local/nvim-data/site/autoload/plug.vim -Force
+    ni "$env:LOCALAPPDATA/nvim-data/site/autoload/plug.vim" -Force
 ```
 
 ### Getting Help


### PR DESCRIPTION
A tidy one liner for the powershell install command. 
Much like the unix one 😄

<!-- ## Before Submitting

- You made sure the existing tests/travis build works.
- You made sure any new features were tested where appropriate.
- You checked a similar feature wasn't already turned down by searching issues & PRs.
-->

Describe the details of your PR ...

This just makes the powershell install command a short one-liner.
- `iwr -useb` works on any version of powershell AFAIK.
- `ni` is `New-Item` and accepts content from `iwr` via the pipe. and the `-Force` on `ni` creates directories if they don't exist.
- the single backtick is the powershell equivalent of the backslash in unix for escaping the newline.