### PR TITLE
Support non-master default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Plug 'SirVer/ultisnips' | Plug 'honza/vim-snippets'
 Plug 'scrooloose/nerdtree', { 'on':  'NERDTreeToggle' }
 Plug 'tpope/vim-fireplace', { 'for': 'clojure' }
 
-" Using a non-master branch
+" Using a non-default branch
 Plug 'rdnetto/YCM-Generator', { 'branch': 'stable' }
 
 " Using a tagged release; wildcard allowed (requires git 1.9.2 or above)

--- a/doc/plug.txt
+++ b/doc/plug.txt
@@ -163,7 +163,7 @@ Example~
     Plug 'scrooloose/nerdtree', { 'on':  'NERDTreeToggle' }
     Plug 'tpope/vim-fireplace', { 'for': 'clojure' }
 
-    " Using a non-master branch
+    " Using a non-default branch
     Plug 'rdnetto/YCM-Generator', { 'branch': 'stable' }
 
     " Using a tagged release; wildcard allowed (requires git 1.9.2 or above)

--- a/plug.vim
+++ b/plug.vim
@@ -25,7 +25,7 @@
 "   Plug 'scrooloose/nerdtree', { 'on':  'NERDTreeToggle' }
 "   Plug 'tpope/vim-fireplace', { 'for': 'clojure' }
 "
-"   " Using a non-master branch
+"   " Using a non-default branch
 "   Plug 'rdnetto/YCM-Generator', { 'branch': 'stable' }
 "
 "   " Using a tagged release; wildcard allowed (requires git 1.9.2 or above)

--- a/plug.vim
+++ b/plug.vim
@@ -646,25 +646,25 @@ function! s:parse_options(arg)
     endif
     let opts.tag = a:arg
   elseif type == s:TYPE.dict
-    call extend(opts, a:arg)
     for opt in ['branch', 'tag', 'commit', 'rtp', 'dir', 'as']
-      if has_key(opts, opt)
-      \ && (type(opts[opt]) != s:TYPE.string || (opt != 'branch' && empty(opts[opt])))
+      if has_key(a:arg, opt)
+      \ && (type(a:arg[opt]) != s:TYPE.string || empty(a:arg[opt]))
         throw printf(opt_errfmt, opt, 'string')
       endif
     endfor
     for opt in ['on', 'for']
-      if has_key(opts, opt)
-      \ && type(opts[opt]) != s:TYPE.list
-      \ && (type(opts[opt]) != s:TYPE.string || empty(opts[opt]))
+      if has_key(a:arg, opt)
+      \ && type(a:arg[opt]) != s:TYPE.list
+      \ && (type(a:arg[opt]) != s:TYPE.string || empty(a:arg[opt]))
         throw printf(opt_errfmt, opt, 'string or list')
       endif
     endfor
-    if has_key(opts, 'do')
-      \ && type(opts.do) != s:TYPE.funcref
-      \ && (type(opts.do) != s:TYPE.string || empty(opts.do))
+    if has_key(a:arg, 'do')
+      \ && type(a:arg.do) != s:TYPE.funcref
+      \ && (type(a:arg.do) != s:TYPE.string || empty(a:arg.do))
         throw printf(opt_errfmt, 'do', 'string or funcref')
     endif
+    call extend(opts, a:arg)
     if has_key(opts, 'dir')
       let opts.dir = s:dirpath(s:plug_expand(opts.dir))
     endif

--- a/plug.vim
+++ b/plug.vim
@@ -2211,6 +2211,14 @@ function! s:system_chomp(...)
   return v:shell_error ? '' : substitute(ret, '\n$', '', '')
 endfunction
 
+function! s:git_get_branch(dir)
+  let result = s:lines(s:system('git symbolic-ref --short HEAD', a:dir))
+  if v:shell_error
+    return ''
+  endif
+  return result[-1]
+endfunction
+
 function! s:git_validate(spec, check_branch)
   let err = ''
   if isdirectory(a:spec.dir)
@@ -2234,6 +2242,9 @@ function! s:git_validate(spec, check_branch)
       endif
     elseif a:check_branch
       let branch = result[0]
+      if empty(branch)
+        let branch = 'HEAD'
+      endif
       " Check tag
       if has_key(a:spec, 'tag')
         let tag = s:system_chomp('git describe --exact-match --tags HEAD 2>&1', a:spec.dir)
@@ -2242,7 +2253,7 @@ function! s:git_validate(spec, check_branch)
                 \ (empty(tag) ? 'N/A' : tag), a:spec.tag)
         endif
       " Check branch
-      elseif a:spec.branch !=# branch
+      elseif a:spec.branch != '' && a:spec.branch !=# branch
         let err = printf('Invalid branch: %s (expected: %s). Try PlugUpdate.',
               \ branch, a:spec.branch)
       endif

--- a/plug.vim
+++ b/plug.vim
@@ -2260,7 +2260,7 @@ function! s:git_validate(spec, check_branch)
       if empty(err)
         let [ahead, behind] = split(s:lastline(s:system([
         \ 'git', 'rev-list', '--count', '--left-right',
-        \ printf('HEAD...origin/%s', a:spec.branch)
+        \ printf('HEAD...origin/%s', branch)
         \ ], a:spec.dir)), '\t')
         if !v:shell_error && ahead
           if behind
@@ -2268,11 +2268,11 @@ function! s:git_validate(spec, check_branch)
             " pushable (and probably not that messed up).
             let err = printf(
                   \ "Diverged from origin/%s (%d commit(s) ahead and %d commit(s) behind!\n"
-                  \ .'Backup local changes and run PlugClean and PlugUpdate to reinstall it.', a:spec.branch, ahead, behind)
+                  \ .'Backup local changes and run PlugClean and PlugUpdate to reinstall it.', branch, ahead, behind)
           else
             let err = printf("Ahead of origin/%s by %d commit(s).\n"
                   \ .'Cannot update until local changes are pushed.',
-                  \ a:spec.branch, ahead)
+                  \ branch, ahead)
           endif
         endif
       endif

--- a/plug.vim
+++ b/plug.vim
@@ -106,7 +106,7 @@ if s:is_win && &shellslash
 else
   let s:me = resolve(expand('<sfile>:p'))
 endif
-let s:base_spec = { 'branch': 'master', 'frozen': 0 }
+let s:base_spec = { 'branch': '', 'frozen': 0 }
 let s:TYPE = {
 \   'string':  type(''),
 \   'list':    type([]),
@@ -649,7 +649,7 @@ function! s:parse_options(arg)
     call extend(opts, a:arg)
     for opt in ['branch', 'tag', 'commit', 'rtp', 'dir', 'as']
       if has_key(opts, opt)
-      \ && (type(opts[opt]) != s:TYPE.string || empty(opts[opt]))
+      \ && (type(opts[opt]) != s:TYPE.string || (opt != 'branch' && empty(opts[opt])))
         throw printf(opt_errfmt, opt, 'string')
       endif
     endfor
@@ -1206,7 +1206,10 @@ function! s:update_finish()
         call s:log4(name, 'Checking out '.tag)
         let out = s:system('git checkout -q '.plug#shellescape(tag).' -- 2>&1', spec.dir)
       else
-        let branch = get(spec, 'branch', 'master')
+        let branch = get(spec, 'branch', '')
+        if empty(branch)
+          let branch = s:git_get_branch(spec.dir)
+        endif
         call s:log4(name, 'Merging origin/'.s:esc(branch))
         let out = s:system('git checkout -q '.plug#shellescape(branch).' -- 2>&1'
               \. (has_key(s:update.new, name) ? '' : ('&& git merge --ff-only '.plug#shellescape('origin/'.branch).' 2>&1')), spec.dir)

--- a/test/workflow.vader
+++ b/test/workflow.vader
@@ -68,13 +68,13 @@ Execute (Test Plug command):
   " Git URI
   Plug 'file:///tmp/vim-plug-test/jg/vim-emoji'
   AssertEqual 'file:///tmp/vim-plug-test/jg/vim-emoji', g:plugs['vim-emoji'].uri
-  AssertEqual 'master', g:plugs['vim-emoji'].branch
+  AssertEqual '', g:plugs['vim-emoji'].branch
   AssertEqual join([g:temp_plugged, 'vim-emoji/'], '/'), g:plugs['vim-emoji'].dir
 
   " vim-scripts/
   Plug 'vim-scripts/beauty256'
   AssertEqual 'file:///tmp/vim-plug-test/vim-scripts/beauty256', g:plugs.beauty256.uri
-  AssertEqual 'master', g:plugs.beauty256.branch
+  AssertEqual '', g:plugs.beauty256.branch
 
   AssertEqual 4, len(g:plugs)
 


### PR DESCRIPTION
https://github.blog/changelog/2020-08-26-set-the-default-branch-for-newly-created-repositories/

GitHub will be change the default branch to `main` for newly created repository. vim-plug use `master` branch for the default. This change look current branch name from HEAD/ref.