### PR TITLE
XDG_DATA_HOME respecting powershell script

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ curl -fLo ~/.var/app/io.neovim.nvim/data/nvim/site/autoload/plug.vim \
 
 ```powershell
 iwr -useb https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim |`
-    ni "$env:LOCALAPPDATA/nvim-data/site/autoload/plug.vim" -Force
+    ni "$(@($env:XDG_DATA_HOME, $env:LOCALAPPDATA)[$null -eq $env:XDG_DATA_HOME])/nvim-data/site/autoload/plug.vim" -Force
 ```
 
 ### Getting Help


### PR DESCRIPTION
The Powershell installation script currently doesn't respect the XDG_DATA_HOME environment variable. The reason it look so ugly is because Powershell doesn't support turnery operators until 7.0. Currently Windows 10 ships with 5.1 and it won't be shipping the latest Powershell until a later date.


 * [x] The script works simply as copying and pasting - You made sure the existing tests/travis build works.
 * [x] Yes - You made sure any new features were tested where appropriate.
 * [x] Probably - You checked a similar feature wasn't already turned down by searching issues & PRs.


