### PR TITLE
Pass empty string for credential.helper

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -1532,7 +1532,7 @@ while 1 " Without TCO, Vim stack is bound to explode
     let [error, _] = s:git_validate(spec, 0)
     if empty(error)
       if pull
-        let cmd = ['git', 'fetch']
+        let cmd = s:git_version_requirement(2) ? ['git', '-c', 'credential.helper=', 'fetch'] : ['git', 'fetch']
         if has_tag && !empty(globpath(spec.dir, '.git/shallow'))
           call extend(cmd, ['--depth', '99999999'])
         endif


### PR DESCRIPTION
Current implementation does not fix on Windows cmd.exe

https://github.com/junegunn/vim-plug/pull/1026 or https://github.com/junegunn/vim-plug/issues/1031


