### PR TITLE
How to make vimrc work when there is no plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,40 +99,42 @@ Add a vim-plug section to your `~/.vimrc` (or `stdpath('config') . '/init.vim'` 
 " Specify a directory for plugins
 " - For Neovim: stdpath('data') . '/plugged'
 " - Avoid using standard Vim directory names like 'plugin'
-call plug#begin('~/.vim/plugged')
+silent! call plug#begin('~/.vim/plugged')
+if exists('g:plug_home') " Only invoke following commands if `plug` is installed
 
-" Make sure you use single quotes
+  " Make sure you use single quotes
 
-" Shorthand notation; fetches https://github.com/junegunn/vim-easy-align
-Plug 'junegunn/vim-easy-align'
+  " Shorthand notation; fetches https://github.com/junegunn/vim-easy-align
+  Plug 'junegunn/vim-easy-align'
 
-" Any valid git URL is allowed
-Plug 'https://github.com/junegunn/vim-github-dashboard.git'
+  " Any valid git URL is allowed
+  Plug 'https://github.com/junegunn/vim-github-dashboard.git'
 
-" Multiple Plug commands can be written in a single line using | separators
-Plug 'SirVer/ultisnips' | Plug 'honza/vim-snippets'
+  " Multiple Plug commands can be written in a single line using | separators
+  Plug 'SirVer/ultisnips' | Plug 'honza/vim-snippets'
 
-" On-demand loading
-Plug 'scrooloose/nerdtree', { 'on':  'NERDTreeToggle' }
-Plug 'tpope/vim-fireplace', { 'for': 'clojure' }
+  " On-demand loading
+  Plug 'scrooloose/nerdtree', { 'on':  'NERDTreeToggle' }
+  Plug 'tpope/vim-fireplace', { 'for': 'clojure' }
 
-" Using a non-default branch
-Plug 'rdnetto/YCM-Generator', { 'branch': 'stable' }
+  " Using a non-default branch
+  Plug 'rdnetto/YCM-Generator', { 'branch': 'stable' }
 
-" Using a tagged release; wildcard allowed (requires git 1.9.2 or above)
-Plug 'fatih/vim-go', { 'tag': '*' }
+  " Using a tagged release; wildcard allowed (requires git 1.9.2 or above)
+  Plug 'fatih/vim-go', { 'tag': '*' }
 
-" Plugin options
-Plug 'nsf/gocode', { 'tag': 'v.20150303', 'rtp': 'vim' }
+  " Plugin options
+  Plug 'nsf/gocode', { 'tag': 'v.20150303', 'rtp': 'vim' }
 
-" Plugin outside ~/.vim/plugged with post-update hook
-Plug 'junegunn/fzf', { 'dir': '~/.fzf', 'do': './install --all' }
+  " Plugin outside ~/.vim/plugged with post-update hook
+  Plug 'junegunn/fzf', { 'dir': '~/.fzf', 'do': './install --all' }
 
-" Unmanaged plugin (manually installed and updated)
-Plug '~/my-prototype-plugin'
+  " Unmanaged plugin (manually installed and updated)
+  Plug '~/my-prototype-plugin'
 
-" Initialize plugin system
-call plug#end()
+  " Initialize plugin system
+  call plug#end()
+endif
 ```
 
 Reload .vimrc and `:PlugInstall` to install plugins.


### PR DESCRIPTION
Use case: user configured `.vimrc`, copied it to another machine, but did not install `plug` there. `.vimrc` will fail with many errors.

Update `README.md` with instructions how to deal with this case.