### PR TITLE
solución:  error de no es una orden del editor,

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,14 @@ curl -fLo ~/.var/app/io.neovim.nvim/data/nvim/site/autoload/plug.vim \
 ###### Windows (PowerShell)
 
 ```powershell
-iwr -useb https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim |`
-    ni "$(@($env:XDG_DATA_HOME, $env:LOCALAPPDATA)[$null -eq $env:XDG_DATA_HOME])/nvim-data/site/autoload/plug.vim" -Force
+md ~\AppData\Local\nvim\autoload
+$uri = 'https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
+(New-Object Net.WebClient).DownloadFile(
+  $uri,
+  $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath(
+    "~\AppData\Local\nvim\autoload\plug.vim"
+  )
+)
 ```
 
 ### Getting Help


### PR DESCRIPTION
si te fijas en los directorios
eso estaba mal y daba muchos errores
pero asi vimplug se descarga directamente en C:\Users\user\AppData\Local\nvim\autoload
y eso soluciona un par de errores