### PR TITLE
Better resolving of relative plugin dirs

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -750,7 +750,9 @@ function! s:parse_options(arg)
     endif
     call extend(opts, a:arg)
     if has_key(opts, 'dir')
-      let opts.dir = s:dirpath(s:plug_expand(opts.dir))
+      exe 'cd' fnameescape(g:plug_home)
+      let opts.dir = s:dirpath(fnamemodify(s:plug_expand(opts.dir), ':p'))
+      cd -
     endif
   else
     throw 'Invalid argument type (expected: string or dictionary)'


### PR DESCRIPTION
When using a relative path such as `'dir': 'some-repo-before-compat-break'` in a `Plug` spec, the folder gets resolved relative to Vim's current directory, which could be anywhere, often the root of a project. I believe it would be far better if this was resolved as relative to `g:plug_home`, so absolute and home-relative `dir` specs remain unchanged, but simple directory names would be in the same place other plugins are kept. This would also mean such plugins are loaded when Vim is opened in another working directory, and can be cleaned away if removed from `.vimrc`.

This works for single level names where the trailing slash is omitted.
