### PR TITLE
Failed to connect to github.com port 443: Timeout

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -769,7 +769,7 @@ function! s:infer_properties(name, repo)
       if repo !~ '/'
         throw printf('Invalid argument: %s (implicit `vim-scripts'' expansion is deprecated)', repo)
       endif
-      let fmt = get(g:, 'plug_url_format', 'https://git::@github.com/%s.git')
+      let fmt = get(g:, 'plug_url_format', 'https://git::@hub.fastgit.org/%s.git')
       let uri = printf(fmt, repo)
     endif
     return { 'dir': s:dirpath(g:plug_home.'/'.a:name), 'uri': uri }
@@ -1165,7 +1165,7 @@ function! s:update_impl(pull, force, args) abort
     let $GIT_TERMINAL_PROMPT = 0
     for plug in values(todo)
       let plug.uri = substitute(plug.uri,
-            \ '^https://git::@github\.com', 'https://github.com', '')
+            \ '^https://git::@hub.fastgit\.org', 'https://hub.fastgit.org', '')
     endfor
   endif
 


### PR DESCRIPTION
Due to github.com is not stable for some contries, e.g. China. So change it to mirror site instead of direct site. This will solve the issue of “Failed to connect to github.com port 443: Timeout".