### PR TITLE
Update README w/ working curl cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ and put it in the "autoload" directory.
 ###### Unix
 
 ```sh
-curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
+curl -kfLo ~/.vim/autoload/plug.vim --create-dirs \
     https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 ```
 
@@ -53,14 +53,14 @@ iwr -useb https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim |`
 ###### Unix, Linux
 
 ```sh
-sh -c 'curl -fLo "${XDG_DATA_HOME:-$HOME/.local/share}"/nvim/site/autoload/plug.vim --create-dirs \
+sh -c 'curl -kfLo "${XDG_DATA_HOME:-$HOME/.local/share}"/nvim/site/autoload/plug.vim --create-dirs \
        https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim'
 ```
 
 ###### Linux (Flatpak)
 
 ```sh
-curl -fLo ~/.var/app/io.neovim.nvim/data/nvim/site/autoload/plug.vim \
+curl -kfLo ~/.var/app/io.neovim.nvim/data/nvim/site/autoload/plug.vim \
     https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 ```
 


### PR DESCRIPTION
Updated the curl cmd to include the -k flag to ignore SSL certification. Idk if that was your intended but w/o the flag you'll get:

```
curl: (60) SSL certificate problem: unable to get local issuer certificate
More details here: https://curl.haxx.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```


Not sure if that's a github thing or what, but just for future reference.