### PR TITLE
Set --origin=origin for git clone commands

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -1208,7 +1208,8 @@ function! s:update_impl(pull, force, args) abort
   normal! 2G
   silent! redraw
 
-  let s:clone_opt = []
+  " Set remote name, overriding a possible user git config's clone.defaultRemoteName
+  let s:clone_opt = ['--origin', 'origin']
   if get(g:, 'plug_shallow', 1)
     call extend(s:clone_opt, ['--depth', '1'])
     if s:git_version_requirement(1, 7, 10)


### PR DESCRIPTION
---

#### Commits _(oldest to newest)_

c78dc4d Set --origin=origin for git clone commands

Otherwise if the user has set a `git config clone.defaultRemoteName
foo`, then vim-plug will fail to detect the latest upstream changes as
the remote will be incorrect, and will repeatedly state that the plugin
repo needs to be cleaned.

<br/>