### PR TITLE
Add --create-dirs option to flatpak installation instrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ sh -c 'curl -fLo "${XDG_DATA_HOME:-$HOME/.local/share}"/nvim/site/autoload/plug.
 ###### Linux (Flatpak)
 
 ```sh
-curl -fLo ~/.var/app/io.neovim.nvim/data/nvim/site/autoload/plug.vim \
+curl -fLo ~/.var/app/io.neovim.nvim/data/nvim/site/autoload/plug.vim --create-dirs \
     https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 ```
 


### PR DESCRIPTION
Without the `--create-dirs` option the `curl` fails if the directories do not exists