### PR TITLE
Fix unexpected cursor movement on on-demand imap loading

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -405,7 +405,7 @@ function! plug#end()
 
   for [map, names] in items(lod.map)
     for [mode, map_prefix, key_prefix] in
-          \ [['i', '<C-O>', ''], ['n', '', ''], ['v', '', 'gv'], ['o', '', '']]
+          \ [['i', '<C-\><C-O>', ''], ['n', '', ''], ['v', '', 'gv'], ['o', '', '']]
       execute printf(
       \ '%snoremap <silent> %s %s:<C-U>call <SID>lod_map(%s, %s, %s, "%s")<CR>',
       \ mode, map, map_prefix, string(map), string(names), mode != 'i', key_prefix)


### PR DESCRIPTION
`i_CTRL-O` may change the cursor position in an unexpected way.
For example, when `autoindent` is set, the user will expect that
`i<Space><Space>asdf<CR><C-O>` will place the cursor right below `a`.
However, `<C-O>` moves the cursor to the first column of line 2.

Expected:
```
  asdf
  █
```
Actual:
```
  asdf
█
```

Therefore, it's desirable to use `i_CTRL-\_CTRL-O`, the variant of
`i_CTRL-O` that does not move the cursor.
