### PR TITLE
README: clarify plugins directory for Windows Vim users

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Add a vim-plug section to your `~/.vimrc` (or `stdpath('config') . '/init.vim'` 
 
 ```vim
 " Specify a directory for plugins
+" - For Windows: '~/vimfiles/plugged'
 " - For Neovim: stdpath('data') . '/plugged'
 " - Avoid using standard Vim directory names like 'plugin'
 call plug#begin('~/.vim/plugged')

--- a/README.md
+++ b/README.md
@@ -97,8 +97,9 @@ Add a vim-plug section to your `~/.vimrc` (or `stdpath('config') . '/init.vim'` 
 
 ```vim
 " Specify a directory for plugins
-" - For Windows: '~/vimfiles/plugged'
-" - For Neovim: stdpath('data') . '/plugged'
+" - For Vim (Linux/macOS): '~/.vim/plugged'
+" - For Vim (Windows): '~/vimfiles/plugged'
+" - For Neovim (Linux/macOS/Windows): stdpath('data') . '/plugged'
 " - Avoid using standard Vim directory names like 'plugin'
 call plug#begin('~/.vim/plugged')
 


### PR DESCRIPTION
The user runtime directory for Vim on Windows is `~/vimfiles` by default, not `~/.vim`. While this doesn't actually affect the functionality of vim-plug, this change would indicate to Windows users that the vim-plug directory for plugins should correspond to this, rather than erroneously creating a new `.vim` folder with only `/plugged` in it. I had made this mistake myself before fixing it manually.

This change would be consistent with the installation instructions for Windows, which installs vim-plug into `~/vimfiles`:
https://github.com/junegunn/vim-plug#windows-powershell