### PR TITLE
Add gitignore so that vim-plug can be managed by vim-plug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
<!-- ## Before Submitting

- You made sure the existing tests/travis build works.
- You made sure any new features were tested where appropriate.
- You checked a similar feature wasn't already turned down by searching issues & PRs.
-->

If you set up vim-plug to manage vim-plug itself, it will create a doc/tags file, which means the repo it is saved in is dirty. Fix this by adding a gitignore.
