### PR TITLE
Fixed Neovim installation documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ curl -fLo ~/.var/app/io.neovim.nvim/data/nvim/site/autoload/plug.vim --create-di
 
 ```powershell
 iwr -useb https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim |`
-    ni "$(@($env:XDG_DATA_HOME, $env:LOCALAPPDATA)[$null -eq $env:XDG_DATA_HOME])/nvim-data/site/autoload/plug.vim" -Force
+    $HOME/AppData/Local/nvim/autoload/plug.vim -Force
 ```
 
 ### Getting Help


### PR DESCRIPTION
<!-- ## Before Submitting

- You made sure the existing tests/travis build works.
- You made sure any new features were tested where appropriate.
- You checked a similar feature wasn't already turned down by searching issues & PRs.
-->

Was trying to install vim-plug into Neovim and the initial installation script did not work. After reviewing a bit about Neovim I found the proper default location to place the plug.vim file. No code is being checked in just documentation. Thanks!
