### PR TITLE
plug#end() should always call s:reload_plugins() fixes #1307

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -398,9 +398,8 @@ function! plug#end()
     if has('syntax') && !exists('g:syntax_on')
       syntax enable
     end
-  else
-    call s:reload_plugins()
   endif
+  call s:reload_plugins()
 endfunction
 
 function! s:loaded_names()

--- a/plug.vim
+++ b/plug.vim
@@ -394,12 +394,19 @@ function! plug#end()
 
   call s:reorg_rtp()
   filetype plugin indent on
+  let g:plug_reload_plugins = get(g:, 'plug_reload_plugins', '')
   if has('vim_starting')
     if has('syntax') && !exists('g:syntax_on')
       syntax enable
     end
+  else
+    if g:plug_reload_plugins != 'force'
+      call s:reload_plugins()
+    endif
   endif
-  call s:reload_plugins()
+  if g:plug_reload_plugins == 'force'
+    call s:reload_plugins()
+  endif
 endfunction
 
 function! s:loaded_names()


### PR DESCRIPTION
<!-- ## Before Submitting

- You made sure the existing tests/travis build works.
- You made sure any new features were tested where appropriate.
- You checked a similar feature wasn't already turned down by searching issues & PRs.
-->

call `s:reload_plugins()` is no longer strictly contingent on `!has('vim_starting')` and now allows for an additional trigger `g:plug_reload_plugins == 'force'`