### PR TITLE
Add `--guess` option in `git checkout`

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -1546,7 +1546,7 @@ endfunction
 
 function! s:checkout_command(spec)
   let a:spec.branch = s:git_origin_branch(a:spec)
-  return ['git', 'checkout', '-q', a:spec.branch, '--']
+  return ['git', 'checkout', '-q', '--guess', a:spec.branch, '--']
 endfunction
 
 function! s:merge_command(spec)


### PR DESCRIPTION
refs #1004

This fixes an error that prevents checking out a branch when the following setting is specified in git config.

``` gitconfig
[checkout]
	guess = false
```

Because checking out branches with vim-plug relies on Git's "guess" functionality, we need to explicitly enable it.