### PR TITLE
Fix breakage to 'PlugUpgrade' under Windows PowerShell.

### DIFF
--- a/plug.vim
+++ b/plug.vim
@@ -2469,9 +2469,11 @@ endfunction
 
 function! s:rm_rf(dir)
   if isdirectory(a:dir)
-    return s:system(s:is_win
-    \ ? 'rmdir /S /Q '.plug#shellescape(a:dir)
-    \ : ['rm', '-rf', a:dir])
+    return s:system(!s:is_win
+    \ ? ['rm', '-rf', a:dir]
+    \ : s:is_powershell(&shell)
+    \ ? ['Remove-Item', '-Recurse', '-Force', a:dir]
+    \ : 'rmdir /S /Q '.plug#shellescape(a:dir))
   endif
 endfunction
 


### PR DESCRIPTION
Commit 09b7c0e has caused this command to emit an error during its cleanup when run on Windows with 'shell' set to PowerShell.

The cause of the failure is that the cleanup logic passes the command string 'rmdir /s /q' to `s:system()` (within `s:rm_rf()`). Before the commit at fault, this command would be written to a batch file and executed by 'cmd.exe'. After the commit, it is passed directly to PowerShell for execution, where 'rmdir' is an alias for 'Remove-Item' and does not support '/s' and '/q' flags.

<!-- ## Before Submitting

- You made sure the existing tests/travis build works.
- You made sure any new features were tested where appropriate.
- You checked a similar feature wasn't already turned down by searching issues & PRs.
-->

Describe the details of your PR ...
