### PR TITLE
Add 'onclean' pre-clean hook option

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ vim.cmd('silent! colorscheme seoul256')
 | `dir`                   | Custom directory for the plugin                             |
 | `as`                    | Use different name for the plugin                           |
 | `do`                    | Post-update hook (string or funcref)                        |
+| `onclean`               | Pre-clean hook (string or funcref)                           |
 | `on`                    | On-demand loading: Commands or `<Plug>`-mappings            |
 | `for`                   | On-demand loading: File types                               |
 | `frozen`                | Do not remove and do not update unless explicitly specified |
@@ -362,6 +363,39 @@ with the bang-versions of the commands: `PlugInstall!` and `PlugUpdate!`.
 > let g:fzf_install = 'yes | ./install'
 > Plug 'junegunn/fzf', { 'do': g:fzf_install }
 > ```
+
+## Pre-clean hooks
+
+If a plugin needs some cleanup task to be performed before `:PlugClean` scans
+and removes plugin directories, use the `onclean` option. It follows the same
+rules as the `do` option: it can be a shell command, a Vim command prefixed
+with `:`, or a Vim function reference.
+
+```vim
+Plug 'junegunn/fzf', { 'onclean': 'rm -f ~/.fzf/tags' }
+Plug 'fatih/vim-go', { 'onclean': ':GoCleanBinaries' }
+Plug 'ycm-core/YouCompleteMe', { 'onclean': function('CleanYCM') }
+```
+
+The hook is executed inside the directory of the plugin, once per
+`:PlugClean` invocation, for every plugin that defines it and is still
+installed, regardless of whether that particular plugin ends up being
+removed. A Vim function reference is called with a dictionary argument
+containing a single `name` field with the name of the plugin.
+
+`onclean` is most useful for cleaning up after a plugin you're about to
+remove, so it's designed to still run even after you delete or comment out
+its `Plug` line: whenever `plug#end()` runs, shell-command and `:`-command
+hooks (not funcrefs, which can't be persisted) are mirrored to a small state
+file (`.onclean_state`) next to `plug.vim` in your `autoload` directory.
+`:PlugClean` consults that file for directories that are no longer declared,
+so the hook still fires right before such a directory is deleted. The entry
+is removed once the directory is gone. Because of this, a funcref `onclean`
+only runs while its `Plug` line is still present.
+
+`:PlugClean` asks `Run onclean hook for <name>: <command>? (y/N)` before
+running each `onclean` hook; answer `y` to run it, anything else to skip
+it. Use `:PlugClean!` to run every hook without being asked.
 
 ### `PlugInstall!` and `PlugUpdate!`
 

--- a/doc/plug.txt
+++ b/doc/plug.txt
@@ -16,6 +16,7 @@ PLUG - TABLE OF CONTENTS                                         *plug* *plug-to
     Keybindings                     |plug-keybindings|
     Post-update hooks               |plug-post-update-hooks|
       PlugInstall! and PlugUpdate!  |pluginstall-and-plugupdate|
+    Pre-clean hooks                 |plug-pre-clean-hooks|
     On-demand loading of plugins    |plug-on-demand-loading-of-plugins|
     Collaborators                   |plug-collaborators|
     License                         |plug-license|
@@ -249,6 +250,7 @@ PLUG OPTIONS                                                      *plug-options*
   `dir`                    | Custom directory for the plugin
   `as`                     | Use different name for the plugin
   `do`                     | Post-update hook (string or funcref)
+  `onclean`                | Pre-clean hook (string or funcref)
   `on`                     | On-demand loading: Commands or <Plug>-mappings
   `for`                    | On-demand loading: File types
   `frozen`                 | Do not remove and do not update unless explicitly specified
@@ -350,6 +352,39 @@ The installer takes the following steps when installing/updating a plugin:
 
 The commands with the `!` suffix ensure that all steps are run
 unconditionally.
+
+
+PRE-CLEAN HOOKS                                           *plug-pre-clean-hooks*
+==============================================================================
+
+If a plugin needs some cleanup task to be performed before `:PlugClean` scans
+and removes plugin directories, use the `onclean` option. It follows the
+same rules as the `do` option: it can be a shell command, a Vim command
+prefixed with `:`, or a Vim function reference.
+>
+    Plug 'junegunn/fzf', { 'onclean': 'rm -f ~/.fzf/tags' }
+    Plug 'fatih/vim-go', { 'onclean': ':GoCleanBinaries' }
+    Plug 'ycm-core/YouCompleteMe', { 'onclean': function('CleanYCM') }
+<
+The hook is executed inside the directory of the plugin, once per
+`:PlugClean` invocation, for every plugin that defines it and is still
+installed, regardless of whether that particular plugin ends up being
+removed. A Vim function reference is called with a dictionary argument
+containing a single `name` field with the name of the plugin.
+
+`onclean` is most useful for cleaning up after a plugin you're about to
+remove, so it's designed to still run even after you delete or comment out
+its `Plug` line: whenever `plug#end()` runs, shell-command and `:`-command
+hooks (not funcrefs, which can't be persisted) are mirrored to a small
+state file (`.onclean_state`) next to `plug.vim` in your `autoload`
+directory. `:PlugClean` consults that file for directories that are no
+longer declared, so the hook still fires right before such a directory is
+deleted. The entry is removed once the directory is gone. Because of this,
+a funcref `onclean` only runs while its `Plug` line is still present.
+
+`:PlugClean` asks `Run onclean hook for <name>: <command>? (y/N)` before
+running each `onclean` hook; answer `y` to run it, anything else to skip
+it. Use `:PlugClean!` to run every hook without being asked.
 
 
 ON-DEMAND LOADING OF PLUGINS                 *plug-on-demand-loading-of-plugins*

--- a/plug.vim
+++ b/plug.vim
@@ -404,6 +404,7 @@ function! plug#end()
   else
     call s:reload_plugins()
   endif
+  call s:onclean_state_sync()
 endfunction
 
 function! s:loaded_names()
@@ -737,11 +738,13 @@ function! s:parse_options(arg)
         throw printf(opt_errfmt, opt, 'string or list')
       endif
     endfor
-    if has_key(a:arg, 'do')
-      \ && type(a:arg.do) != s:TYPE.funcref
-      \ && (type(a:arg.do) != s:TYPE.string || empty(a:arg.do))
-        throw printf(opt_errfmt, 'do', 'string or funcref')
-    endif
+    for opt in ['do', 'onclean']
+      if has_key(a:arg, opt)
+      \ && type(a:arg[opt]) != s:TYPE.funcref
+      \ && (type(a:arg[opt]) != s:TYPE.string || empty(a:arg[opt]))
+        throw printf(opt_errfmt, opt, 'string or funcref')
+      endif
+    endfor
     call extend(opts, a:arg)
     if has_key(opts, 'dir')
       let opts.dir = s:dirpath(s:plug_expand(opts.dir))
@@ -2477,7 +2480,133 @@ function! s:rm_rf(dir)
   endif
 endfunction
 
+" Onclean hooks must survive the removal of their `Plug` line (that's the
+" main point of the option: cleaning up after a plugin that is going away),
+" so string-type hooks (shell command or ':Cmd') are mirrored to a small
+" state file in g:plug_home, keyed by plugin directory, independent of
+" g:plugs. Funcref hooks cannot be serialized and therefore only run while
+" the `Plug` line declaring them is still present.
+function! s:onclean_state_file()
+  return fnamemodify(s:me, ':h') . '/.onclean_state'
+endfunction
+
+function! s:onclean_state_load()
+  let file = s:onclean_state_file()
+  if !filereadable(file)
+    return {}
+  endif
+  let lines = readfile(file)
+  let state = {}
+  let i = 0
+  while i + 1 < len(lines)
+    let state[lines[i]] = lines[i + 1]
+    let i += 2
+  endwhile
+  return state
+endfunction
+
+function! s:onclean_state_save(state)
+  let lines = []
+  for [dir, cmd] in items(a:state)
+    call extend(lines, [dir, cmd])
+  endfor
+  try
+    call writefile(lines, s:onclean_state_file())
+  catch
+  endtry
+endfunction
+
+" Called from plug#end() so the state file always reflects the hooks
+" currently declared in the vimrc, while keeping entries for plugins that
+" were since undeclared but whose directory hasn't been cleaned yet.
+function! s:onclean_state_sync()
+  let state = s:onclean_state_load()
+  call filter(state, 'isdirectory(v:key)')
+  for spec in values(g:plugs)
+    if has_key(spec, 'onclean') && type(spec.onclean) == s:TYPE.string
+      let state[spec.dir] = spec.onclean
+    endif
+  endfor
+  call s:onclean_state_save(state)
+endfunction
+
+" Called from s:delete() once a directory has actually been removed.
+function! s:onclean_state_forget(dir)
+  let state = s:onclean_state_load()
+  if has_key(state, a:dir)
+    call remove(state, a:dir)
+    call s:onclean_state_save(state)
+  endif
+endfunction
+
+function! s:run_onclean(name, spec)
+  let error = ''
+  let type = type(a:spec.onclean)
+  if type == s:TYPE.string
+    if a:spec.onclean[0] == ':'
+      if has_key(g:plugs, a:name) && !get(s:loaded, a:name, 0)
+        let s:loaded[a:name] = 1
+        call s:reorg_rtp()
+      endif
+      call s:load_plugin(a:spec)
+      try
+        execute a:spec.onclean[1:]
+      catch
+        let error = v:exception
+      endtry
+    else
+      let error = s:bang(a:spec.onclean)
+    endif
+  elseif type == s:TYPE.funcref
+    try
+      call s:load_plugin(a:spec)
+      call a:spec.onclean({ 'name': a:name })
+    catch
+      let error = v:exception
+    endtry
+  else
+    let error = 'Invalid hook type'
+  endif
+  return error
+endfunction
+
+function! s:onclean_hooks(force)
+  let todo = []
+  let seen = {}
+  for [name, spec] in items(g:plugs)
+    if has_key(spec, 'onclean') && isdirectory(get(spec, 'dir', ''))
+      call add(todo, [name, spec])
+      let seen[spec.dir] = 1
+    endif
+  endfor
+  for [dir, cmd] in items(s:onclean_state_load())
+    if !has_key(seen, dir) && isdirectory(dir)
+      call add(todo, [fnamemodify(s:trim(dir), ':t'), { 'dir': dir, 'onclean': cmd }])
+    endif
+  endfor
+
+  if empty(todo)
+    return
+  endif
+
+  echom 'Running onclean hooks'
+  let cwd = getcwd()
+  for [name, spec] in todo
+    " Confirm before running any onclean hook, unless forced (:PlugClean!).
+    if !a:force && !s:ask_no_interrupt(printf('Run onclean hook for %s: `%s`?', name, spec.onclean))
+      echom printf('- onclean hook for %s ... Skipped', name)
+      continue
+    endif
+    execute 'cd' s:esc(spec.dir)
+    let error = s:run_onclean(name, spec)
+    execute 'cd' s:esc(cwd)
+    echom empty(error) ? printf('- onclean hook for %s ... OK', name)
+                      \ : printf('- onclean hook for %s ... Error: %s', name, error)
+  endfor
+endfunction
+
 function! s:clean(force)
+  call s:onclean_hooks(a:force)
   call s:prepare()
   call append(0, 'Searching for invalid plugins in '.g:plug_home)
   call append(1, '')
@@ -2568,6 +2697,7 @@ function! s:delete(range, force)
         setlocal modifiable
         if empty(err)
           call setline(l1, '~'.line[1:])
+          call s:onclean_state_forget(line[2:])
           let s:clean_count += 1
         else
           delete _


### PR DESCRIPTION
<!-- ## Before Submitting

- You made sure the existing tests/travis build works.
- You made sure any new features were tested where appropriate.
- You checked a similar feature wasn't already turned down by searching issues & PRs.
-->

Lets a plugin run a shell command, Vim command, or funcref right before `:PlugClean` scans and removes plugin directories, mirroring the existing `'do'` post-update hook.

Now you can do things like this:

```vim
Plug 'chudur-budur/mlir-vim', { 'do': './install.py', 'onclean': './uninstall.sh' }
```

It persists the state of plugins in the `autoload/.onclean_state` file so that whenever a plugin installation line with this hook is commented out, it will still know which one it's going to call the hook on. i.e. -- 

```vim
" Plug 'chudur-budur/mlir-vim', { 'do': './install.py', 'onclean': './uninstall.sh' }
```

will run `./uninstall.sh` upon `:PlugClean` command, even if after the line is commented out.